### PR TITLE
pipcook-app: fix the interface member ends

### DIFF
--- a/packages/pipcook-app/src/models/objectDetection.ts
+++ b/packages/pipcook-app/src/models/objectDetection.ts
@@ -14,15 +14,15 @@ import * as path from 'path'
 import { getEasParam, EasConfigI } from '../utils/utils';
 
 export interface MetaDataI {
-  device?: 'cpu' | 'gpu',
-  baseLearningRate?: number,
-  numWorkers?: number,
-  maxIter?: number,
-  numGpus?: number,
+  device?: 'cpu' | 'gpu';
+  baseLearningRate?: number;
+  numWorkers?: number;
+  maxIter?: number;
+  numGpus?: number;
 }
 
 export interface TrainInfoI {
-  testSplit?: number,
+  testSplit?: number;
   annotationFileName: string;
 }
 


### PR DESCRIPTION
The changed lines are inconsistent with

https://github.com/alibaba/pipcook/blob/715f3355bb08c2109228f07c4f5341f0bb268824/packages/pipcook-app/src/models/objectDetection.ts#L26

and it's recommended to use the sign `;` as the terminated.