### PR TITLE
cli: fix the type casts by `as` keyword

### DIFF
--- a/packages/pipcook-cli/assets/pluginPackage/src/dataAccess.ts
+++ b/packages/pipcook-cli/assets/pluginPackage/src/dataAccess.ts
@@ -2,7 +2,7 @@ import { UniformSampleData, OriginSampleData, ArgsType, parseAnnotation, DataAcc
 
 
 const templateDataAccess: DataAccessType = async (data: OriginSampleData[] | OriginSampleData, args?: ArgsType): Promise<UniformSampleData> => {
-  return <UniformSampleData>{};
+  return {} as UniformSampleData;
 }
 
 export default templateDataAccess;

--- a/packages/pipcook-cli/assets/pluginPackage/src/dataCollect.ts
+++ b/packages/pipcook-cli/assets/pluginPackage/src/dataCollect.ts
@@ -1,7 +1,7 @@
 import {OriginSampleData, ArgsType, DataCollectType} from '@pipcook/pipcook-core';
 
 const templateDataCollect: DataCollectType = async (args?: ArgsType): Promise<OriginSampleData> => {
-  return <OriginSampleData>{};
+  return {} as OriginSampleData;
 }
 
 export default templateDataCollect;

--- a/packages/pipcook-cli/assets/pluginPackage/src/dataProcess.ts
+++ b/packages/pipcook-cli/assets/pluginPackage/src/dataProcess.ts
@@ -1,7 +1,7 @@
 import {DataProcessType, UniformSampleData, ArgsType} from '@pipcook/pipcook-core'
 
 const templateDataProcess: DataProcessType = async (data: UniformSampleData, args?: ArgsType): Promise<UniformSampleData> => {
-  return <UniformSampleData>{};
+  return {} as UniformSampleData;
 }
 
 export default templateDataProcess;

--- a/packages/pipcook-cli/assets/pluginPackage/src/modelDeploy.ts
+++ b/packages/pipcook-cli/assets/pluginPackage/src/modelDeploy.ts
@@ -1,7 +1,7 @@
 import {ModelDeployType, ArgsType} from '@pipcook/pipcook-core'
 
 const templateModelDeploy: ModelDeployType = async (data: any, model: any, args?: ArgsType): Promise<any> => {
-  return <any>{};
+  return {} as any;
 }
 
 export default templateModelDeploy;

--- a/packages/pipcook-cli/assets/pluginPackage/src/modelEvaluate.ts
+++ b/packages/pipcook-cli/assets/pluginPackage/src/modelEvaluate.ts
@@ -2,7 +2,7 @@
 import {PipcookModel, UniformSampleData, ArgsType, ModelEvaluateType, EvaluateResult} from '@pipcook/pipcook-core';
 
 const templateModelEvaluate: ModelEvaluateType = async (data: UniformSampleData, model: PipcookModel, args?: ArgsType): Promise<EvaluateResult> => {
-  return <EvaluateResult>{};
+  return {} as EvaluateResult;
 }
 
 export default templateModelEvaluate;

--- a/packages/pipcook-cli/assets/pluginPackage/src/modelLoad.ts
+++ b/packages/pipcook-cli/assets/pluginPackage/src/modelLoad.ts
@@ -1,7 +1,7 @@
 import {ModelLoadType, PipcookModel, UniformSampleData, ModelLoadArgsType} from '@pipcook/pipcook-core';
 
 const templateModelLoad: ModelLoadType = async (data: UniformSampleData, args?: ModelLoadArgsType): Promise<PipcookModel> => {
-  return <PipcookModel>{};
+  return {} as PipcookModel;
 }
 
 export default templateModelLoad;

--- a/packages/pipcook-cli/assets/pluginPackage/src/modelTrain.ts
+++ b/packages/pipcook-cli/assets/pluginPackage/src/modelTrain.ts
@@ -2,8 +2,7 @@
 import {ModelTrainType, PipcookModel, UniformSampleData} from '@pipcook/pipcook-core';
 
 const templateModelTrain: ModelTrainType = async (data: UniformSampleData, model: PipcookModel): Promise<PipcookModel> => {
-  return <PipcookModel>{};
+  return {} as PipcookModel;
 }
 
 export default templateModelTrain;
-


### PR DESCRIPTION
The cast in `<T>` is not recommended because it's conflicts with jsx/tsx syntax.

See:

- https://palantir.github.io/tslint/rules/no-angle-bracket-type-assertion/
- https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-assertions.md