### PR TITLE
meta, lint: extends the recommended rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,15 +1,10 @@
 module.exports = {
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
-  rules: {
-      'no-var': "error",
-      '@typescript-eslint/consistent-type-definitions': [
-          "error",
-          "interface"
-      ]  
+  'extends': [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  'rules': {
+    '@typescript-eslint/no-var-requires': 'off',
   },
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module",
-  },
-}
+};


### PR DESCRIPTION
This PR changes the eslint rules extending some recommended ones:

- `eslint:recommended`
- `plugin:@typescript-eslint/eslint-recommended`
- `plugin:@typescript-eslint/recommended`

The result for the current codebase is:

```sh
620 problems (207 errors, 413 warnings)
```

But never mind, I'll create some other PRs to fix these errors and warnings, once all is gone, the CI is able to work for us.