### PR TITLE
build: fix the python-node package lint errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+example
+docs
+dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,12 @@ module.exports = {
   ],
   'rules': {
     '@typescript-eslint/no-var-requires': 'off',
+    '@typescript-eslint/camelcase': 'off',
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      {
+        'functions': false,
+      }
+    ]
   },
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typescript": "^3.7.2"
   },
   "scripts": {
-    "eslint": "eslint packages --ext .ts",
+    "lint": "eslint . --ext .ts",
     "doc": "rm -rf ./doc && typedoc --plugin typedoc-plugin-markdown"
   },
   "dependencies": {

--- a/packages/pipcook-python-node/src/communication/communication.ts
+++ b/packages/pipcook-python-node/src/communication/communication.ts
@@ -95,15 +95,16 @@ export default class Executor {
     socketSubscriber.receive()
     .then((msg: Buffer[]) => {
       msg.forEach((item, index) => {
+        let json = null;
         try {
-          const json = JSON.parse(item.toString());
-          if (json.name === 'stdout') {
-            console.log('[PYTHON: ]', json.text);
-          } else if (json.name === 'stderr') {
-            console.error('[PYTHON: ]', json.text);
-          }
-        } catch (e) {
-
+          json = JSON.parse(item.toString());
+        } catch (err) {
+          json = {};
+        }
+        if (json.name === 'stdout') {
+          console.log('[PYTHON: ]', json.text);
+        } else if (json.name === 'stderr') {
+          console.log('[PYTHON: ]', json.text);
         }
       });
       Executor.handleSubscriberMsg(socketSubscriber);
@@ -145,7 +146,8 @@ export default class Executor {
               message.traceback = json.traceback;
             }
           }
-        } catch (err) {   
+        } catch (err) {
+          // TODO: how to handle with this error?
         }
       });
       session.dealerMsg = message;

--- a/packages/pipcook-python-node/src/core/python-helper.ts
+++ b/packages/pipcook-python-node/src/core/python-helper.ts
@@ -84,8 +84,8 @@ function createProxy(object: any, statements: string[]) {
  * @param identifier: the identifier used in python codes that linked between python and object
  */
 export function getObject(identifier: string, statements: string[]): PythonObject {
-  const object: PythonObject = () => {};
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const object: PythonObject = function callable() {};
   object.__pipcook__identifier = identifier;
-  const proxy = createProxy(object, statements);
-  return proxy;
+  return createProxy(object, statements);
 }


### PR DESCRIPTION
This changes some lint infra like:

- script name to "lint"
- add .eslintignore