### PR TITLE
build: fix pipcook-core lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
   ],
   'rules': {
+    'no-useless-escape': 'off',
     '@typescript-eslint/no-var-requires': 'off',
   },
 };

--- a/packages/pipcook-core/src/board/board.ts
+++ b/packages/pipcook-core/src/board/board.ts
@@ -51,10 +51,13 @@ export function serverModel(fastify: any) {
         // pipecook will arrange logs and models in the same name convention
         let log: any = {};
         try {
-          if(fs.pathExistsSync(path.join(process.cwd(), 'pipcook-output', modelNameSplit, `log.json`))) {
-            log = require(path.join(process.cwd(), 'pipcook-output', modelNameSplit ,`log.json`));
+          const logPath = path.join(process.cwd(), 'pipcook-output', modelNameSplit, 'log.json');
+          if (fs.pathExistsSync(logPath)) {
+            log = require(logPath);
           }
-        } finally {}
+        } finally {
+          // TODO(yorkie): move the "model push" here?
+        }
         models.push({
           modelId: modelNameSplit,  modelName: modelNameSplit,
           evaluation: JSON.stringify(log.latestEvaluateResult),
@@ -200,7 +203,7 @@ export async function serveRunner(runner: PipcookRunner) {
       return;
     }
   
-    const modelPlugin = <ModelLoadType>modelComponent.plugin;
+    const modelPlugin = modelComponent.plugin as ModelLoadType;
     if (!(modelComponent.params && modelComponent.params.modelId)) {
       logError('Please provide model id in prediction pipeline');
       return;
@@ -222,7 +225,7 @@ export async function serveRunner(runner: PipcookRunner) {
 
   // This is for /status endpoint. Used when the pipeline is running and the front-end needs to know its status.
   runner.fastify.get('/status', async (req: any, reply: any) => {
-    const model = <PipcookModel>runner.latestModel;
+    const model = runner.latestModel as PipcookModel;
     return {
       status: runner.status,
       type: model && model.type,

--- a/packages/pipcook-core/src/core/core-helper.ts
+++ b/packages/pipcook-core/src/core/core-helper.ts
@@ -13,7 +13,6 @@ import {flatMap} from 'rxjs/operators';
 import {DATA, MODEL, EVALUATE, DEPLOYMENT, MODELTOSAVE, ORIGINDATA} from '../constants/other';
 import {DATAACCESS} from '../constants/plugins';
 
-
 /**
  * Retreive relative logs required to be stored.
  * @param pipcookRunner : The pipcookRunner object
@@ -24,46 +23,46 @@ export function getLog(pipcookRunner: PipcookRunner) {
   return pipcookRunner;
 }
 
-  /**
-   * According to return type of plugin, we need to update runner.
-   * @param updatedType: updated return type of plugin
-   * @param result: lasted return data of plugin
-   */
-  export async function assignLatestResult(updatedType: string, result: any, self: PipcookRunner, saveModelCallback?: Function) {
-    switch (updatedType) {
-      case DATA:
-        self.latestSampleData = result;
-        break;
-      case MODEL:
-        self.latestModel = result;
-        break;
-      case EVALUATE:
-        self.latestEvaluateResult = result;
-        break;
-      case DEPLOYMENT:
-        self.latestDeploymentResult = result;
-        break;
-      case ORIGINDATA:
-        self.latestOriginSampleData = result;
-        break;
-      case MODELTOSAVE:
-        self.latestModel = result;
-        if (Array.isArray(result) && result.length > 0) {
-          result = result[0];
-        }
-        await result.save(path.join(<string>self.logDir, 'model'));
-        if (saveModelCallback) {
-          const valueMap = 
-          (self.latestSampleData && self.latestSampleData.metaData 
-            && self.latestSampleData.metaData.label && self.latestSampleData.metaData.label.valueMap) || {};
-          fs.writeJSONSync(path.join(process.cwd(), '.temp', self.pipelineId, 'label.json'), valueMap);
-          await saveModelCallback(path.join(<string>self.logDir, 'model'), self.pipelineId, path.join(process.cwd(), '.temp', self.pipelineId, 'label.json'));
-        } 
-        break;
-      default:
-        throw new Error('Returned Data Type is not recognized');
-    }
+/**
+ * According to return type of plugin, we need to update runner.
+ * @param updatedType: updated return type of plugin
+ * @param result: lasted return data of plugin
+ */
+export async function assignLatestResult(updatedType: string, result: any, self: PipcookRunner, saveModelCallback?: Function) {
+  switch (updatedType) {
+    case DATA:
+      self.latestSampleData = result;
+      break;
+    case MODEL:
+      self.latestModel = result;
+      break;
+    case EVALUATE:
+      self.latestEvaluateResult = result;
+      break;
+    case DEPLOYMENT:
+      self.latestDeploymentResult = result;
+      break;
+    case ORIGINDATA:
+      self.latestOriginSampleData = result;
+      break;
+    case MODELTOSAVE:
+      self.latestModel = result;
+      if (Array.isArray(result) && result.length > 0) {
+        result = result[0];
+      }
+      await result.save(path.join(self.logDir as string, 'model'));
+      if (saveModelCallback) {
+        const valueMap = 
+        (self.latestSampleData && self.latestSampleData.metaData 
+          && self.latestSampleData.metaData.label && self.latestSampleData.metaData.label.valueMap) || {};
+        fs.writeJSONSync(path.join(process.cwd(), '.temp', self.pipelineId, 'label.json'), valueMap);
+        await saveModelCallback(path.join(self.logDir as string, 'model'), self.pipelineId, path.join(process.cwd(), '.temp', self.pipelineId, 'label.json'));
+      } 
+      break;
+    default:
+      throw new Error('Returned Data Type is not recognized');
   }
+}
 
 /**
  * create the pipeline according to the components given. The pipelien serializes all components sepcified
@@ -77,7 +76,7 @@ export function createPipeline(components: PipcookComponentResult[], self: Pipco
   const insertParams = {
     pipelineId: self.pipelineId
   }
-  const firstObservable = <Observable<any>>firstComponent.observer(self.latestOriginSampleData, self.latestModel, insertParams);
+  const firstObservable = firstComponent.observer(self.latestOriginSampleData, self.latestModel, insertParams) as Observable<any>;
   self.updatedType = firstComponent.returnType;
 
   const flatMapArray: any = [];
@@ -106,7 +105,6 @@ export function createPipeline(components: PipcookComponentResult[], self: Pipco
   }
   
   return firstObservable.pipe(
-    // @ts-ignore
     ...flatMapArray
   );
 }
@@ -158,7 +156,7 @@ export async function runPredict(runner: PipcookRunner, request: any) {
   const dataProcess = components.find((e) => e.type === 'dataProcess');
   const modelDeploy = components.find((e) => e.type === 'modelDeploy');
 
-  const result = await (<ModelDeployType>modelDeploy.plugin)({},{},{
+  const result = await (modelDeploy.plugin as ModelDeployType)({}, {}, {
     data, dataAccess, model: latestModel, dataProcess
   });
 

--- a/packages/pipcook-core/src/core/core.ts
+++ b/packages/pipcook-core/src/core/core.ts
@@ -100,7 +100,7 @@ export class PipcookRunner {
   savePipcook = async () => {
     // store Pipcook log
     const json = JSON.stringify(getLog(this), getCircularReplacer());
-    fs.outputFileSync(path.join(<string>this.logDir, 'log.json'), json);
+    fs.outputFileSync(path.join(this.logDir as string, 'log.json'), json);
   }
 
   /**
@@ -163,7 +163,7 @@ export class PipcookRunner {
     pipeline.subscribe((result: any) => {
       // success handle
       components[components.length - 1].status = 'success';
-      assignLatestResult(<string>this.updatedType, result, this);
+      assignLatestResult(this.updatedType as string, result, this);
     }, async (error: Error) => {
       await this.handleError(error, components);
       if (errorCallback) {

--- a/packages/pipcook-core/src/index.ts
+++ b/packages/pipcook-core/src/index.ts
@@ -1,7 +1,7 @@
 // types
 export {OriginSampleData, UniformSampleData, UniformTfSampleData, UniformGeneralSampleData} from './types/data';
 export {PipcookModel} from './types/model';
-export {DataDescriptor, metaData, EvaluateResult} from './types/other';
+export {DataDescriptor, MetaData, EvaluateResult} from './types/other';
 export {DataCollectType, DataAccessType, DataProcessType, ModelLoadType, 
   ModelTrainType, ModelEvaluateType, ModelDeployType, ArgsType, ModelLoadArgsType, ModelArgsType} from './types/plugins';
 export {DataCollect, DataAccess, DataProcess, ModelLoad, ModelTrain, ModelEvaluate, ModelDeploy} from './components/PipcookLifeCycleComponent';

--- a/packages/pipcook-core/src/types/component.ts
+++ b/packages/pipcook-core/src/types/component.ts
@@ -4,9 +4,8 @@ import {OriginSampleData, UniformSampleData, InsertParams} from './data';
 import {PipObject} from './other';
 import { Subscribable } from 'rxjs';
 
-export interface PipcookComponent {
-
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PipcookComponent {}
 
 interface ObserverFunc {
   (data: OriginSampleData | OriginSampleData[]| UniformSampleData | UniformSampleData[] | null, 

--- a/packages/pipcook-core/src/types/data.ts
+++ b/packages/pipcook-core/src/types/data.ts
@@ -1,5 +1,5 @@
 import * as tf from '@tensorflow/tfjs-node-gpu';
-import {metaData, statistic} from './other';
+import {MetaData, Statistic} from './other';
 
 export interface OriginSampleData {
   trainDataPath: string;
@@ -7,12 +7,12 @@ export interface OriginSampleData {
   validationDataPath?: string;
 }
 
-export interface UniformSampleData{
+export interface UniformSampleData {
   trainData: any;
   validationData?: any;
   testData?: any;
-  metaData: metaData;
-  dataStatistics?: statistic[];
+  metaData: MetaData;
+  dataStatistics?: Statistic[];
   validationResult?: {
     result: boolean;
     message: string;
@@ -31,5 +31,5 @@ export interface UniformGeneralSampleData extends UniformSampleData {
   testData?: string;
 }
 
-export interface InsertParams {
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface InsertParams {}

--- a/packages/pipcook-core/src/types/other.ts
+++ b/packages/pipcook-core/src/types/other.ts
@@ -8,7 +8,7 @@ export interface DataDescriptor {
   valueMap?: any;
 }
 
-export interface metaData {
+export interface MetaData {
   feature: DataDescriptor;
   label: DataDescriptor;
   trainSize?: number;
@@ -16,7 +16,7 @@ export interface metaData {
   testSize?: number;
 }
 
-export interface statistic {
+export interface Statistic {
   metricName: string;
   metricValue: number;
 }
@@ -36,6 +36,5 @@ export interface EvaluateResult {
   [key: string]: any;
 }
 
-export interface PipcookMergeArray {
-  
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PipcookMergeArray {}

--- a/packages/pipcook-core/src/types/plugins.ts
+++ b/packages/pipcook-core/src/types/plugins.ts
@@ -4,8 +4,8 @@ import {PipcookModel} from './model';
 import {EvaluateResult, DeploymentResult} from './other';
 import {PipcookComponentResult} from './component';
 
-export interface PipcookPlugin {
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PipcookPlugin {}
 
 export interface ArgsType {
   [key: string]: any;

--- a/packages/pipcook-core/src/utils/serverProcess.ts
+++ b/packages/pipcook-core/src/utils/serverProcess.ts
@@ -12,7 +12,7 @@ export async function processImageClassification(data: any, dataAccess: PipcookC
   const trainDataPath = path.join(process.cwd(), '.temp');
   try {
     data.forEach((dataImage: any) => {
-      const fileName = 'image-'+Date.now()+'.jpg';
+      const fileName = `image-${Date.now()}.jpg`;
       fs.outputFileSync(path.join(trainDataPath, fileName), dataImage, {encoding: 'base64'});
       if (type === IMAGE_CLASSIFICATION) {
         createAnnotationFile(trainDataPath, fileName, trainDataPath, 'no');
@@ -43,10 +43,10 @@ export async function processImageClassification(data: any, dataAccess: PipcookC
     let result: any = {
       trainDataPath,
     }
-    const dataAccessPlugin = <DataAccessType>dataAccess.plugin;
+    const dataAccessPlugin = dataAccess.plugin as DataAccessType;
     result = await dataAccessPlugin(result, dataAccess.params);
     if (dataProcess) {
-      const dataProcessPlugin = <DataProcessType>dataProcess.plugin;
+      const dataProcessPlugin = dataProcess.plugin as DataProcessType;
       result = await dataProcessPlugin(result, dataProcess.params);
     }
     result = result.trainData.map((e: any) => {
@@ -76,10 +76,10 @@ export async function processTextClassification(data: any, dataAccess: PipcookCo
       let result: any = {
         trainDataPath: path.join(trainDataPath, 'train.csv'),
       }
-      const dataAccessPlugin = <DataAccessType>dataAccess.plugin;
+      const dataAccessPlugin = dataAccess.plugin as DataAccessType;
       result = await dataAccessPlugin(result, dataAccess.params);
       if (dataProcess) {
-        const dataProcessPlugin = <DataProcessType>dataProcess.plugin;
+        const dataProcessPlugin = dataProcess.plugin as DataProcessType;
         result = await dataProcessPlugin(result, dataProcess.params);
       }
       result = result.trainData.map((e: any) => {


### PR DESCRIPTION
Escape is always good, so it disables the rule "no-useless-escape", too.