### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,9 @@ RUN apt-get update \
   && apt-get --no-install-recommends install -y libsm6 libxext6 libxrender-dev
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x \
-  && apt-get --no-install-recommends -y install nodejs npm wget \
+  && apt-get --no-install-recommends -y install nodejs npm wget lsof \
   && npm install n -g && n stable && PATH="$PATH" \
-  && npm install @pipcook/pipcook-cli -g && mv /usr/bin/python /usr/bin/python.bak && ln -s /usr/bin/python3.7 /usr/bin/python \
-  && apt-get --no-install-recommends -y install lsof
+  && npm install @pipcook/pipcook-cli -g && mv /usr/bin/python /usr/bin/python.bak && ln -s /usr/bin/python3.7 /usr/bin/python
 
 ENV TF_FORCE_GPU_ALLOW_GROWTH=true
 ENV LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,25 @@ EXPOSE 7778
 
 ## install pipcook dependencies
 
-RUN apt-get update && echo 'Y' | apt install software-properties-common && echo '\n' | add-apt-repository ppa:deadsnakes/ppa \
-  && echo 'Y' | apt install python3.7 && echo 'Y' | apt-get install python3-setuptools && echo 'Y' | apt-get install curl \
-  && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.7 get-pip.py && ln -s /usr/bin/python3.7 /usr/bin/python \
-  && pip install torch torchvision && pip install opencv-python && echo 'Y' | apt install git && echo 'Y' | apt install build-essential \
-  && echo 'Y' | apt-get install python3.7-dev && pip install 'git+https://github.com/facebookresearch/fvcore' && pip install cython \
+RUN apt-get update \
+  && apt-get --no-install-recommends install -y apt-utils ca-certificates software-properties-common \
+  && echo '\n' | add-apt-repository ppa:deadsnakes/ppa \
+  && apt-get --no-install-recommends install -y python3.7 curl python3-setuptools \
+  && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+  && python3.7 get-pip.py && ln -s /usr/bin/python3.7 /usr/bin/python \
+  && pip install torch torchvision && pip install opencv-python \
+  && apt-get --no-install-recommends install git build-essential python3.7-dev \
+  && pip install 'git+https://github.com/facebookresearch/fvcore' \
+  && pip install cython \
   && pip install 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI' \
   && pip install 'git+https://github.com/facebookresearch/detectron2.git' \
-  && echo 'Y' | apt-get install -y libsm6 libxext6 libxrender-dev
+  && apt-get --no-install-recommends install -y libsm6 libxext6 libxrender-dev
 
-RUN apt-get update && apt-get install -y software-properties-common && curl -sL https://deb.nodesource.com/setup_12.x \
-  && echo 'Y' | apt-get install nodejs && echo 'Y' | apt install npm \
-  && npm install n -g && apt install wget && n stable && PATH="$PATH" \
+RUN curl -sL https://deb.nodesource.com/setup_12.x \
+  && apt-get --no-install-recommends -y install nodejs npm wget \
+  && npm install n -g && n stable && PATH="$PATH" \
   && npm install @pipcook/pipcook-cli -g && mv /usr/bin/python /usr/bin/python.bak && ln -s /usr/bin/python3.7 /usr/bin/python \
-  && apt install lsof
+  && apt-get --no-install-recommends -y install lsof
 
 ENV TF_FORCE_GPU_ALLOW_GROWTH=true
 ENV LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is

1.  Slow because "apt-utils" not installed

2. to avoid build to exits with error without having certificate

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>