### PR TITLE
core: remove the unused interface and fix type

### DIFF
--- a/packages/pipcook-core/src/types/component.ts
+++ b/packages/pipcook-core/src/types/component.ts
@@ -4,9 +4,6 @@ import {OriginSampleData, UniformSampleData, InsertParams} from './data';
 import {PipObject} from './other';
 import { Subscribable } from 'rxjs';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface PipcookComponent {}
-
 interface ObserverFunc {
   (data: OriginSampleData | OriginSampleData[]| UniformSampleData | UniformSampleData[] | null, 
     model: PipcookModel | PipcookModel[] |null, insertParams: InsertParams): Subscribable<any>;
@@ -15,7 +12,7 @@ interface ObserverFunc {
 export interface PipcookComponentResult {
   type: 'dataCollect' | 'dataAccess' | 'dataProcess' | 'modelLoad' | 'modelTrain' | 'modelEvaluate' | 'modelDeploy'; 
   plugin?: PipcookPlugin;
-  mergeComponents?: PipcookComponent[][];
+  mergeComponents?: PipcookComponentResult[][];
   params?: PipObject;
   observer?: ObserverFunc;
   returnType: string;
@@ -23,10 +20,6 @@ export interface PipcookComponentResult {
   status: 'not execute' | 'running' | 'success' | 'failure';
 }
 
-export interface PipcookLifeCycleComponent extends PipcookComponent{
+export interface PipcookLifeCycleComponent {
   (plugin: PipcookPlugin, params?: PipObject): PipcookComponentResult;
 }
-
-// export interface DataMergeComponent extends PipcookComponent {
-//   (...mergeComponents: PipcookComponentResult[][]): PipcookComponentResult;
-// }


### PR DESCRIPTION
See https://github.com/alibaba/pipcook/blob/master/packages/pipcook-core/src/core/core-helper.ts#L138, it iterators `mergeComponents` for `PipcookComponentResult[]` instead of `PipcookComponent[]`, I'm not sure why tsc ignore this, but it gets fixed now and removed the interface `PipcookComponent`.