### PR TITLE
build, doc: fix the typedoc mode to file

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,4 +1,4 @@
-- [API Reference](/pipcook/typedoc)
+- [API Reference](/pipcook/typedoc/)
 - Translations
   - [English](/)
   - [中文](/zh-cn/)

--- a/docs/zh-cn/_navbar.md
+++ b/docs/zh-cn/_navbar.md
@@ -1,4 +1,4 @@
-- [API 文档](/pipcook/typedoc)
+- [API 文档](/pipcook/typedoc/)
 - 语言
   - [English](/)
   - [中文](/zh-cn/)

--- a/typedoc.json
+++ b/typedoc.json
@@ -14,3 +14,4 @@
   "excludeExternals": "true",
   "readme": "none"
 }
+

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,13 +1,16 @@
 {
   "name": "Pipcook",
-  "mode": "modules",
+  "mode": "file",
   "out": "docs/typedoc",
   "theme": "default",
   "ignoreCompilerErrors": "false",
   "preserveConstEnums": "true",
-  "exclude": "*_test.ts",
+  "externalPattern": [
+    "**/assets/**/*.ts",
+    "**/*_test.ts"
+  ],
+  "entryPoint": "packages/core/src/index.ts",
   "stripInternal": "false",
   "excludeExternals": "true",
-  "readme": "none",
-  "categorizeByGroup": "true"
+  "readme": "none"
 }


### PR DESCRIPTION
This changes the mode to file and fixes links to API References.