### PR TITLE
core: simplify the RunConfigI definitions

### DIFF
--- a/packages/core/src/constants/plugins.ts
+++ b/packages/core/src/constants/plugins.ts
@@ -1,3 +1,5 @@
+import { PluginTypeI } from '../types/plugins';
+
 export const DATACOLLECT = 'dataCollect';
 export const DATAACCESS = 'dataAccess';
 export const DATAPROCESS = 'dataProcess';
@@ -6,10 +8,6 @@ export const MODELDEFINE = 'modelDefine';
 export const MODELTRAIN = 'modelTrain';
 export const MODELEVALUATE = 'modelEvaluate';
 export const MODELDEPLOY = 'modelDeploy';
-
-type PluginTypeI = 
-  'dataCollect' | 'dataAccess' | 'dataProcess' | 'modelLoad' | 'modelDefine' |'modelTrain' | 'modelEvaluate' | 'modelDeploy';
-
 export const PLUGINS: PluginTypeI[] = [
   DATACOLLECT,
   DATAACCESS,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,3 +1,5 @@
+import { PluginTypeI } from './plugins';
+
 export interface Config {
   version: string;
 }
@@ -9,13 +11,6 @@ export interface RunConfigParam {
 
 export interface RunConfigI {
   plugins: {
-    dataCollect?: RunConfigParam;
-    dataAccess?: RunConfigParam;
-    dataProcess?: RunConfigParam;
-    modelLoad?: RunConfigParam;
-    modelDefine?: RunConfigParam;
-    modelTrain?: RunConfigParam;
-    modelEvaluate?: RunConfigParam;
-    modelDeploy?: RunConfigParam;
+    [key in PluginTypeI]: RunConfigParam;
   };
 }

--- a/packages/core/src/types/plugins.ts
+++ b/packages/core/src/types/plugins.ts
@@ -3,6 +3,8 @@ import { UniDataset } from './data/common';
 import { UniModel } from './model';
 import { EvaluateResult } from './other';
 
+export type PluginTypeI = 'dataCollect' | 'dataAccess' | 'dataProcess' | 'modelLoad' | 'modelDefine' |'modelTrain' | 'modelEvaluate' | 'modelDeploy';
+
 export interface ArgsType {
   pipelineId: string;
   modelDir: string;


### PR DESCRIPTION
1. Move the `PluginTypeI` into types.
2. Simplify the `RunConfigI` interface.