### PR TITLE
build: specify NAPI_VERSION to fix the node-addon-api issue

### DIFF
--- a/packages/boa/binding.gyp
+++ b/packages/boa/binding.gyp
@@ -36,6 +36,7 @@
       "defines": [
         "NAPI_CPP_EXCEPTIONS",
         "NAPI_EXPERIMENTAL",
+        "NAPI_VERSION=6",
       ],
       "conditions": [
         ['OS=="mac"', {


### PR DESCRIPTION
This is to fix #99 which is a compiler error on Node.js 10.13.x~10.15.x, because there is a weird setup for NAPI_VERSION with NAPI_EXPERINMENT, and node-addon-api will not handle that, I have a root fix at https://github.com/nodejs/node-addon-api/pull/703.

But let's have this land to fix #99 ASAP.