### PR TITLE
plugin, core: fail the pipeline when evaluation is not pass

### DIFF
--- a/packages/core/src/runner/helper.ts
+++ b/packages/core/src/runner/helper.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs-extra';
 
 import { PipcookRunner } from './index';
 import { PipcookComponentResult } from '../types/component';
+import { EvaluateError } from '../types/other';
 import { logCurrentExecution } from '../utils/logger';
 import { Observable, from } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
@@ -45,6 +46,9 @@ export async function assignLatestResult(updatedType: string, result: any, self:
   case EVALUATE:
     console.log('evaluate result: ', result);
     self.latestEvaluateResult = result;
+    if (!self.latestEvaluateResult.pass) {
+      throw new EvaluateError(self.latestEvaluateResult);
+    }
     break;
   case DEPLOYMENT:
     self.latestDeploymentResult = result;

--- a/packages/core/src/types/other.ts
+++ b/packages/core/src/types/other.ts
@@ -15,7 +15,7 @@ export interface PipObject {
 }
 
 export interface EvaluateResult {
-  pass: boolean;
+  pass?: boolean;
   [key: string]: any;
 }
 

--- a/packages/core/src/types/other.ts
+++ b/packages/core/src/types/other.ts
@@ -15,7 +15,16 @@ export interface PipObject {
 }
 
 export interface EvaluateResult {
+  pass: boolean;
   [key: string]: any;
+}
+
+export class EvaluateError extends TypeError {
+  public result: EvaluateResult;
+  constructor(r: EvaluateResult) {
+    super(`the evaluate result is not pass, ${JSON.stringify(r, null, 2)}`);
+    this.result = r;
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/plugins/model-evaluate/bayesian-model-evaluate/src/index.ts
+++ b/packages/plugins/model-evaluate/bayesian-model-evaluate/src/index.ts
@@ -24,7 +24,7 @@ const bayesianModelEvaluate: ModelEvaluateType
 
     sys.path.insert(0, path.join(__dirname, 'assets'));
 
-    const { modelDir } = args;
+    const { modelDir, expectAccuracy = 0.95 } = args;
     const { testLoader, metadata } = data;
     const classifier = model.model;
 
@@ -33,9 +33,10 @@ const bayesianModelEvaluate: ModelEvaluateType
 
     const feature_words = get_all_words_list(path.join(modelDir, 'feature_words.pkl'));
     const feature_list = TextFeatures(text_list[1], feature_words);
-    const test_accuracy = classifier.score(feature_list, text_list[2]);
+    const accuracy = classifier.score(feature_list, text_list[2]);
     return {
-      accuracy: test_accuracy
+      pass: accuracy >= parseInt(expectAccuracy),
+      accuracy
     };
   };
 

--- a/packages/plugins/model-evaluate/image-classification-tfjs-model-evaluate/src/index.ts
+++ b/packages/plugins/model-evaluate/image-classification-tfjs-model-evaluate/src/index.ts
@@ -41,11 +41,8 @@ const ModelEvalute: ModelEvaluateType =
     // sample data must contain test data
     if (testLoader) {
       const count = await testLoader.len();
-
       const batches = parseInt(String(count / batchSize));
-
       const testDataSet = await createDataset(testLoader, metadata.labelMap);
-
       const ds = testDataSet.repeat().batch(batchSize);
       let evaluateResult: any = await model.model.evaluateDataset(ds as tf.data.Dataset<{}>, {
         batches
@@ -54,19 +51,20 @@ const ModelEvalute: ModelEvaluateType =
       if (!Array.isArray(evaluateResult)) {
         evaluateResult = [ evaluateResult ];
       }
-
       let metrics = [ 'loss' ];
       if (model.metrics) {
         metrics = [ ...metrics, ...model.metrics ];
       }
-      const result: any = {};
+
+      // TODO: valid how this model works.
+      const result: EvaluateResult = { pass: true };
       metrics.forEach((metric, index) => {
         result[metric] = evaluateResult[index].dataSync();
       });
       return result;
-    } 
-  
-    return {};
+    }
+    // just skiped if no test loader.
+    return { pass: true };
   };
 
 export default ModelEvalute;

--- a/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/src/index.ts
+++ b/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/src/index.ts
@@ -14,17 +14,12 @@ const detectronModelEvaluate: ModelEvaluateType = async (data: CocoDataset, mode
     const { COCOEvaluator, inference_on_dataset } = boa.import('detectron2.evaluation');
     const { build_detection_test_loader } = boa.import('detectron2.data');
 
-    register_coco_instances("test_dataset", {}, data.testAnnotationPath, path.join(data.testAnnotationPath, '..'));
-    cfg.DATASETS.TEST = [ "test_dataset" ];
+    register_coco_instances('test_dataset', {}, data.testAnnotationPath, path.join(data.testAnnotationPath, '..'));
+    cfg.DATASETS.TEST = [ 'test_dataset' ];
 
-    const evaluator = COCOEvaluator("test_dataset", cfg, false, boa.kwargs({ output_dir: modelDir }));
-    const val_loader = build_detection_test_loader(cfg, "val_dataset");
-    const result = inference_on_dataset(trainer.model, val_loader, evaluator);
-
-    return {
-      pass: result > expectResult,
-      result
-    };
+    const evaluator = COCOEvaluator('test_dataset', cfg, false, boa.kwargs({ output_dir: modelDir }));
+    const val_loader = build_detection_test_loader(cfg, 'val_dataset');
+    return inference_on_dataset(trainer.model, val_loader, evaluator);
   }
 };
 

--- a/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/src/index.ts
+++ b/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/src/index.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 const boa = require('@pipcook/boa');
 
 const detectronModelEvaluate: ModelEvaluateType = async (data: CocoDataset, model: UniModel, args: ArgsType): Promise<any> => {
-  let { modelDir, expectResult = 0.9 } = args;
+  let { modelDir } = args;
   const { register_coco_instances } = boa.import('detectron2.data.datasets');
   const { testLoader } = data;
   const cfg = model.config;

--- a/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/src/index.ts
+++ b/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/src/index.ts
@@ -4,12 +4,8 @@ import * as path from 'path';
 const boa = require('@pipcook/boa');
 
 const detectronModelEvaluate: ModelEvaluateType = async (data: CocoDataset, model: UniModel, args: ArgsType): Promise<any> => {
-  let {
-    modelDir
-  } = args;
-
+  let { modelDir, expectResult = 0.9 } = args;
   const { register_coco_instances } = boa.import('detectron2.data.datasets');
-
   const { testLoader } = data;
   const cfg = model.config;
 
@@ -22,13 +18,12 @@ const detectronModelEvaluate: ModelEvaluateType = async (data: CocoDataset, mode
     cfg.DATASETS.TEST = [ "test_dataset" ];
 
     const evaluator = COCOEvaluator("test_dataset", cfg, false, boa.kwargs({ output_dir: modelDir }));
-      
     const val_loader = build_detection_test_loader(cfg, "val_dataset");
-
-    const val_result = inference_on_dataset(trainer.model, val_loader, evaluator);
+    const result = inference_on_dataset(trainer.model, val_loader, evaluator);
 
     return {
-      result: val_result
+      pass: result > expectResult,
+      result
     };
   }
 };

--- a/test/pipelines/text-bayes-classification.json
+++ b/test/pipelines/text-bayes-classification.json
@@ -19,7 +19,10 @@
       "package": "./packages/plugins/model-train/bayesian-model-train"
     },
     "modelEvaluate": {
-      "package": "./packages/plugins/model-evaluate/bayesian-model-evaluate"
+      "package": "./packages/plugins/model-evaluate/bayesian-model-evaluate",
+      "params": {
+        "expectAccracy": 0.9
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes #129 by introducing a pass field on `EvaluateResult` interface, the core will throw a corresponding `EvaluateError` when this field is not set true.