### PR TITLE
core: correct the coco's id in public utils

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pipcook/pipcook-core",
-	"version": "0.5.16",
+	"version": "0.5.17",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipcook/pipcook-core",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/core/src/utils/public.ts
+++ b/packages/core/src/utils/public.ts
@@ -235,7 +235,7 @@ export async function convertPascal2CocoFileOutput(files: string[], targetPath: 
       }
       const cocoItem: any = {
         id: cocoJson.annotations.length + 1,
-        image_id: i,
+        image_id: i + 1,
         category_id: id,
         segmentation: [],
         iscrowd: 0

--- a/packages/core/src/utils/public_test.ts
+++ b/packages/core/src/utils/public_test.ts
@@ -1,0 +1,60 @@
+import { convertPascal2CocoFileOutput, createAnnotationFromJson } from './public';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as uuid from 'uuid';
+
+describe('public utils', () => {
+  it('should generate correct coco json from pascal voc format', async () => {
+    const dir = process.cwd();
+    const file = uuid.v1();
+    await createAnnotationFromJson(dir, {
+      annotation: {
+        folder: [
+          dir
+        ],
+        filename: [
+          file + '.jpg'
+        ],
+        size: [
+          {
+            width: [
+              '750'
+            ],
+            height: [
+              '310'
+            ]
+          }
+        ],
+        object: [
+          {
+            name: [
+              'test'
+            ],
+            bndbox: [
+              {
+                xmin: [
+                  '134'
+                ],
+                ymin: [
+                  '0'
+                ],
+                xmax: [
+                  '325'
+                ],
+                ymax: [
+                  '310'
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    await convertPascal2CocoFileOutput([ path.join(dir, file + '.xml') ], path.join(dir, file + '.json'));
+    const json = await fs.readJSON(path.join(dir, file + '.json'));
+    expect(json.annotations[0].image_id).toBe(1);
+    await fs.remove(file + '.json');
+    await fs.remove(file + '.xml');
+  });
+});


### PR DESCRIPTION
the converter from pascal to coco has some problems where the id of image is not corresponding to image_id in annotations. Just to fix it