### PR TITLE
core: remove `any` types for `lifecycle.ts`

### DIFF
--- a/packages/core/src/components/lifecycle.ts
+++ b/packages/core/src/components/lifecycle.ts
@@ -16,8 +16,10 @@ import {
   ModelLoadType,
   ModelDefineType,
   ModelTrainType,
-  ModelEvaluateType
+  ModelEvaluateType,
+  PluginTypeI
 } from '../types/plugins';
+import { PipObject } from '../types/other';
 import {
   DATACOLLECT,
   DATAACCESS,
@@ -27,7 +29,6 @@ import {
   MODELTRAIN,
   MODELEVALUATE
 } from '../constants/plugins';
-import { UniDataset } from '../types/data/common';
 
 /**
  * The is the factory function to produce Pipcook Component.
@@ -35,8 +36,7 @@ import { UniDataset } from '../types/data/common';
  * @param plugin: plugin
  * @param params: plugin's parameters
  */
-function produceResultFactory(type: 'dataCollect' | 'dataAccess' | 'dataProcess' | 'modelLoad' | 'modelDefine' |'modelTrain' | 'modelEvaluate' | 'modelDeploy',
-  plugin: PipcookPlugin, params? : any): PipcookComponentResult {
+function produceResultFactory(type: PluginTypeI, plugin: PipcookPlugin, params?: PipObject): PipcookComponentResult {
   const result: PipcookComponentResult = {
     type, 
     plugin,
@@ -55,7 +55,7 @@ function produceResultFactory(type: 'dataCollect' | 'dataAccess' | 'dataProcess'
  * @param plugin: plugin
  * @param params: plugin's parameters
  */
-export const DataCollect: PipcookLifeCycleComponent = (plugin: DataCollectType, params?: any) => {
+export const DataCollect: PipcookLifeCycleComponent = (plugin: DataCollectType, params?: PipObject) => {
   const result = produceResultFactory(DATACOLLECT, plugin, params);
   result.observer = (data, model, insertParams) => {
     return from(plugin({ ...params, ...insertParams }));
@@ -68,9 +68,9 @@ export const DataCollect: PipcookLifeCycleComponent = (plugin: DataCollectType, 
  * @param plugin 
  * @param params 
  */
-export const DataAccess: PipcookLifeCycleComponent = (plugin: DataAccessType, params?: any) => {
+export const DataAccess: PipcookLifeCycleComponent = (plugin: DataAccessType, params?: PipObject) => {
   const result = produceResultFactory(DATAACCESS, plugin, params);
-  result.observer = (data: any, model, insertParams) => {
+  result.observer = (data, model, insertParams) => {
     return from(plugin({ ...params, ...insertParams }));
   };
   result.returnType = DATA;
@@ -82,9 +82,9 @@ export const DataAccess: PipcookLifeCycleComponent = (plugin: DataAccessType, pa
  * @param plugin 
  * @param params 
  */
-export const DataProcess: PipcookLifeCycleComponent = (plugin: DataProcessType, params?: any) => {
+export const DataProcess: PipcookLifeCycleComponent = (plugin: DataProcessType, params?: PipObject) => {
   const result = produceResultFactory(DATAPROCESS, plugin, params);
-  result.observer = (data: UniDataset, model, insertParams) => {
+  result.observer = (data, model, insertParams) => {
     if (!data.metadata) {
       data.metadata = {};
     }
@@ -110,9 +110,9 @@ export const DataProcess: PipcookLifeCycleComponent = (plugin: DataProcessType, 
  * @param plugin 
  * @param params 
  */
-export const ModelLoad: PipcookLifeCycleComponent = (plugin: ModelLoadType, params?: any) => {
+export const ModelLoad: PipcookLifeCycleComponent = (plugin: ModelLoadType, params?: PipObject) => {
   const result = produceResultFactory(MODELLOAD, plugin, params);
-  result.observer = (data: any, model, insertParams) => {
+  result.observer = (data, model, insertParams) => {
     return from(plugin(data, { ...params, ...insertParams }));
   };
   result.returnType = MODEL;
@@ -124,9 +124,9 @@ export const ModelLoad: PipcookLifeCycleComponent = (plugin: ModelLoadType, para
  * @param plugin 
  * @param params 
  */
-export const ModelDefine: PipcookLifeCycleComponent = (plugin: ModelDefineType, params?: any) => {
+export const ModelDefine: PipcookLifeCycleComponent = (plugin: ModelDefineType, params?: PipObject) => {
   const result = produceResultFactory(MODELDEFINE, plugin, params);
-  result.observer = (data: any, model, insertParams) => {
+  result.observer = (data, model, insertParams) => {
     return from(plugin(data, { ...params, ...insertParams }));
   };
   result.returnType = MODEL;
@@ -138,9 +138,9 @@ export const ModelDefine: PipcookLifeCycleComponent = (plugin: ModelDefineType, 
  * @param plugin 
  * @param params 
  */
-export const ModelTrain: PipcookLifeCycleComponent = (plugin: ModelTrainType, params?: any) => {
+export const ModelTrain: PipcookLifeCycleComponent = (plugin: ModelTrainType, params?: PipObject) => {
   const result = produceResultFactory(MODELTRAIN, plugin, params);
-  result.observer = (data: any, model, insertParams) => {
+  result.observer = (data, model, insertParams) => {
     return from(plugin(data, model, {
       ...params, ...insertParams, 
       saveModel: async (callback: Function) => {
@@ -157,9 +157,9 @@ export const ModelTrain: PipcookLifeCycleComponent = (plugin: ModelTrainType, pa
  * @param plugin 
  * @param params 
  */
-export const ModelEvaluate: PipcookLifeCycleComponent = (plugin: ModelEvaluateType, params?: any) => {
+export const ModelEvaluate: PipcookLifeCycleComponent = (plugin: ModelEvaluateType, params?: PipObject) => {
   const result = produceResultFactory(MODELEVALUATE, plugin, params);
-  result.observer = (data: any, model, insertParams) => {
+  result.observer = (data, model, insertParams) => {
     return from(plugin(data, model, { ...params, ...insertParams }));
   };
   result.returnType = EVALUATE;

--- a/packages/core/src/types/other.ts
+++ b/packages/core/src/types/other.ts
@@ -10,9 +10,7 @@ export interface DeploymentResult {
   extraData: any;
 } 
 
-export interface PipObject {
-  [key: string]: any;
-}
+export type PipObject = Record<string, any>
 
 export interface EvaluateResult {
   [key: string]: any;

--- a/packages/core/src/types/plugins.ts
+++ b/packages/core/src/types/plugins.ts
@@ -2,15 +2,11 @@
 import { UniDataset, Sample, Metadata } from './data/common';
 import { UniModel } from './model';
 import { EvaluateResult } from './other';
+import { InsertParams } from './component';
 
 export type PluginTypeI = 'dataCollect' | 'dataAccess' | 'dataProcess' | 'modelLoad' | 'modelDefine' |'modelTrain' | 'modelEvaluate' | 'modelDeploy';
 
-export interface ArgsType {
-  pipelineId: string;
-  modelDir: string;
-  dataDir: string;
-  [key: string]: any;
-}
+export type ArgsType = InsertParams & Record<string, any>
 
 export interface ModelArgsType extends ArgsType {
   train: boolean;


### PR DESCRIPTION
fix [#72](https://github.com/alibaba/pipcook/issues/72)

**details**
- Replace `any` for pipcook plugin params with the existing `PipObject`
- Remove `any` that could be inferred by other definition
- Use TypeScript built-in generic types first
