### PR TITLE
fix evaluate pass check and a bug in plugin

### DIFF
--- a/packages/core/src/runner/helper.ts
+++ b/packages/core/src/runner/helper.ts
@@ -46,7 +46,7 @@ export async function assignLatestResult(updatedType: string, result: any, self:
   case EVALUATE:
     console.log('evaluate result: ', result);
     self.latestEvaluateResult = result;
-    if (!self.latestEvaluateResult.pass) {
+    if (self.latestEvaluateResult.pass === false) {
       throw new EvaluateError(self.latestEvaluateResult);
     }
     break;

--- a/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/package-lock.json
+++ b/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pipcook/plugins-object-detection-detectron-model-evaluate",
-	"version": "0.5.10",
+	"version": "0.5.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/package.json
+++ b/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipcook/plugins-object-detection-detectron-model-evaluate",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/src/index.ts
+++ b/packages/plugins/model-evaluate/object-detection-detectron-model-evaluate/src/index.ts
@@ -18,7 +18,7 @@ const detectronModelEvaluate: ModelEvaluateType = async (data: CocoDataset, mode
     cfg.DATASETS.TEST = [ 'test_dataset' ];
 
     const evaluator = COCOEvaluator('test_dataset', cfg, false, boa.kwargs({ output_dir: modelDir }));
-    const val_loader = build_detection_test_loader(cfg, 'val_dataset');
+    const val_loader = build_detection_test_loader(cfg, 'test_dataset');
     return inference_on_dataset(trainer.model, val_loader, evaluator);
   }
 };


### PR DESCRIPTION
This PR includes
- only if the evaluate pass return false, the core will throw errors
- the dataset in detectron evaluate should be 'test_dataset'