### PR TITLE
core: remove `any` of plugin's lifecycle

### DIFF
--- a/packages/core/src/components/lifecycle.ts
+++ b/packages/core/src/components/lifecycle.ts
@@ -36,8 +36,8 @@ import {
  * @param plugin: plugin
  * @param params: plugin's parameters
  */
-function produceResultFactory(type: PluginTypeI, plugin: PipcookPlugin, params?: PipObject): PipcookComponentResult {
-  const result: PipcookComponentResult = {
+function produceResultFactory<T extends PipcookPlugin>(type: PluginTypeI, plugin: T, params?: PipObject): PipcookComponentResult<T> {
+  const result: PipcookComponentResult<T> = {
     type, 
     plugin,
     previousComponent: null,
@@ -55,7 +55,7 @@ function produceResultFactory(type: PluginTypeI, plugin: PipcookPlugin, params?:
  * @param plugin: plugin
  * @param params: plugin's parameters
  */
-export const DataCollect: PipcookLifeCycleComponent = (plugin: DataCollectType, params?: PipObject) => {
+export const DataCollect: PipcookLifeCycleComponent<DataCollectType> = (plugin, params?) => {
   const result = produceResultFactory(DATACOLLECT, plugin, params);
   result.observer = (data, model, insertParams) => {
     return from(plugin({ ...params, ...insertParams }));
@@ -68,7 +68,7 @@ export const DataCollect: PipcookLifeCycleComponent = (plugin: DataCollectType, 
  * @param plugin 
  * @param params 
  */
-export const DataAccess: PipcookLifeCycleComponent = (plugin: DataAccessType, params?: PipObject) => {
+export const DataAccess: PipcookLifeCycleComponent<DataAccessType> = (plugin, params?) => {
   const result = produceResultFactory(DATAACCESS, plugin, params);
   result.observer = (data, model, insertParams) => {
     return from(plugin({ ...params, ...insertParams }));
@@ -82,7 +82,7 @@ export const DataAccess: PipcookLifeCycleComponent = (plugin: DataAccessType, pa
  * @param plugin 
  * @param params 
  */
-export const DataProcess: PipcookLifeCycleComponent = (plugin: DataProcessType, params?: PipObject) => {
+export const DataProcess: PipcookLifeCycleComponent<DataProcessType> = (plugin, params?) => {
   const result = produceResultFactory(DATAPROCESS, plugin, params);
   result.observer = (data, model, insertParams) => {
     if (!data.metadata) {
@@ -110,7 +110,7 @@ export const DataProcess: PipcookLifeCycleComponent = (plugin: DataProcessType, 
  * @param plugin 
  * @param params 
  */
-export const ModelLoad: PipcookLifeCycleComponent = (plugin: ModelLoadType, params?: PipObject) => {
+export const ModelLoad: PipcookLifeCycleComponent<ModelLoadType> = (plugin, params?) => {
   const result = produceResultFactory(MODELLOAD, plugin, params);
   result.observer = (data, model, insertParams) => {
     return from(plugin(data, { ...params, ...insertParams }));
@@ -124,7 +124,7 @@ export const ModelLoad: PipcookLifeCycleComponent = (plugin: ModelLoadType, para
  * @param plugin 
  * @param params 
  */
-export const ModelDefine: PipcookLifeCycleComponent = (plugin: ModelDefineType, params?: PipObject) => {
+export const ModelDefine: PipcookLifeCycleComponent<ModelDefineType> = (plugin, params?) => {
   const result = produceResultFactory(MODELDEFINE, plugin, params);
   result.observer = (data, model, insertParams) => {
     return from(plugin(data, { ...params, ...insertParams }));
@@ -138,7 +138,7 @@ export const ModelDefine: PipcookLifeCycleComponent = (plugin: ModelDefineType, 
  * @param plugin 
  * @param params 
  */
-export const ModelTrain: PipcookLifeCycleComponent = (plugin: ModelTrainType, params?: PipObject) => {
+export const ModelTrain: PipcookLifeCycleComponent<ModelTrainType> = (plugin, params?) => {
   const result = produceResultFactory(MODELTRAIN, plugin, params);
   result.observer = (data, model, insertParams) => {
     return from(plugin(data, model, {
@@ -157,7 +157,7 @@ export const ModelTrain: PipcookLifeCycleComponent = (plugin: ModelTrainType, pa
  * @param plugin 
  * @param params 
  */
-export const ModelEvaluate: PipcookLifeCycleComponent = (plugin: ModelEvaluateType, params?: PipObject) => {
+export const ModelEvaluate: PipcookLifeCycleComponent<ModelEvaluateType> = (plugin, params?) => {
   const result = produceResultFactory(MODELEVALUATE, plugin, params);
   result.observer = (data, model, insertParams) => {
     return from(plugin(data, model, { ...params, ...insertParams }));

--- a/packages/core/src/runner/helper.ts
+++ b/packages/core/src/runner/helper.ts
@@ -3,12 +3,12 @@
  */
 import * as path from 'path';
 import * as fs from 'fs-extra';
+import { from } from 'rxjs';
 
 import { PipcookRunner } from './index';
 import { PipcookComponentResult } from '../types/component';
 import { EvaluateError } from '../types/other';
 import { logCurrentExecution } from '../utils/logger';
-import { Observable, from } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
 import { DATA, MODEL, EVALUATE, DEPLOYMENT, MODELTOSAVE } from '../constants/other';
 
@@ -82,7 +82,7 @@ export function createPipeline(components: PipcookComponentResult[], self: Pipco
     modelDir: path.join(self.logDir, 'model'),
     dataDir: path.join(self.logDir, 'data')
   };
-  const firstObservable = firstComponent.observer(null, self.latestModel, insertParams) as Observable<any>;
+  const firstObservable = firstComponent.observer(null, self.latestModel, insertParams);
   self.updatedType = firstComponent.returnType;
 
   const flatMapArray: any = [];

--- a/packages/core/src/types/component.ts
+++ b/packages/core/src/types/component.ts
@@ -2,8 +2,7 @@ import { Observable } from 'rxjs';
 import { PipcookPlugin } from './plugins';
 import { UniModel } from './model';
 import { UniDataset } from './data/common';
-import { PipObject } from './other';
-import { PromisedValueOf } from './utility';
+import { PipObject, PromisedValueOf } from './other';
 
 export interface InsertParams {
   pipelineId: string;

--- a/packages/core/src/types/component.ts
+++ b/packages/core/src/types/component.ts
@@ -1,8 +1,9 @@
+import { Observable } from 'rxjs';
 import { PipcookPlugin } from './plugins';
 import { UniModel } from './model';
 import { UniDataset } from './data/common';
 import { PipObject } from './other';
-import { Subscribable } from 'rxjs';
+import { PromisedValueOf } from './utility';
 
 export interface InsertParams {
   pipelineId: string;
@@ -10,8 +11,8 @@ export interface InsertParams {
   dataDir: string;
 }
 
-interface ObserverFunc {
-  (data: UniDataset, model: UniModel |null, insertParams: InsertParams): Subscribable<any>;
+interface ObserverFunc<T extends PipcookPlugin> {
+  (data: UniDataset, model: UniModel |null, insertParams: InsertParams): Observable<PromisedValueOf<ReturnType<T>>>;
 }
 
 type ResultType = 
@@ -24,21 +25,21 @@ type ResultType =
   'modelEvaluate' |
   'modelDeploy' ;
 
-export interface PipcookComponentResult {
+export interface PipcookComponentResult<T extends PipcookPlugin = PipcookPlugin> {
   type: ResultType;
   plugin?: PipcookPlugin;
-  mergeComponents?: PipcookComponentResult[][];
+  mergeComponents?: PipcookComponentResult<T>[][];
   params?: PipObject;
-  observer?: ObserverFunc;
+  observer?: ObserverFunc<T>;
   returnType?: string;
-  previousComponent: PipcookComponentResult | null;
+  previousComponent: PipcookComponentResult<T> | null;
   status: 'not execute' | 'running' | 'success' | 'failure';
   package?: string;
   version?: string;
 }
 
-export interface PipcookLifeCycleComponent {
-  (plugin: PipcookPlugin, params?: PipObject): PipcookComponentResult;
+export interface PipcookLifeCycleComponent<T extends PipcookPlugin> {
+  (plugin: T, params?: PipObject): PipcookComponentResult<T>;
 }
 
 export interface PipcookModelDeployResult {
@@ -46,5 +47,5 @@ export interface PipcookModelDeployResult {
 }
 
 export interface PipcookLifeCycleTypes {
-  [pluginType: string]: PipcookLifeCycleComponent;
+  [pluginType: string]: PipcookLifeCycleComponent<PipcookPlugin>;
 }

--- a/packages/core/src/types/other.ts
+++ b/packages/core/src/types/other.ts
@@ -27,3 +27,8 @@ export class EvaluateError extends TypeError {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PipcookMergeArray {}
+
+/**
+ * Retrieve the type of fulfillment value of a Promise
+ */
+export type PromisedValueOf<T extends Promise<any>> = T extends Promise<infer P> ? P : never

--- a/packages/core/src/types/plugins.ts
+++ b/packages/core/src/types/plugins.ts
@@ -24,9 +24,8 @@ export interface ModelTrainArgsType extends ArgsType {
   saveModel: SaveModelFunction;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PipcookPlugin {
-  (...args: any): any;
+  (...args: any[]): Promise<void | UniDataset | UniModel | EvaluateResult>;
 }
 
 export interface DataCollectType extends PipcookPlugin {

--- a/packages/core/src/types/utility.ts
+++ b/packages/core/src/types/utility.ts
@@ -1,0 +1,5 @@
+
+/**
+ * Retrieve the type of fulfillment value of a Promise
+ */
+export type PromisedValueOf<T extends Promise<any>> = T extends Promise<infer P> ? P : never

--- a/packages/core/src/types/utility.ts
+++ b/packages/core/src/types/utility.ts
@@ -1,5 +1,0 @@
-
-/**
- * Retrieve the type of fulfillment value of a Promise
- */
-export type PromisedValueOf<T extends Promise<any>> = T extends Promise<infer P> ? P : never


### PR DESCRIPTION
fix [#72](https://github.com/alibaba/pipcook/issues/72)

**details**
- Add custom generic tool `PromisedValueOf`
- Remove `any` of observable in plugin's lifecycle