### PR TITLE
core: purge deploy stage from plugins

### DIFF
--- a/packages/core/src/constants/other.ts
+++ b/packages/core/src/constants/other.ts
@@ -6,7 +6,6 @@ export const STATUS_RUNNING = 'running';
 export const DATA = 'data';
 export const MODEL = 'model';
 export const EVALUATE = 'evaluate';
-export const DEPLOYMENT = 'deployment';
 export const MERGE = 'merge';
 export const MODELTOSAVE = 'modeltosave';
 export const ORIGINDATA = 'origindata';

--- a/packages/core/src/constants/other_test.ts
+++ b/packages/core/src/constants/other_test.ts
@@ -10,7 +10,6 @@ describe('other constants', () => {
     expect(other.DATA).toEqual('data');
     expect(other.MODEL).toEqual('model');
     expect(other.EVALUATE).toEqual('evaluate');
-    expect(other.DEPLOYMENT).toEqual('deployment');
     expect(other.MERGE).toEqual('merge');
     expect(other.MODELTOSAVE).toEqual('modeltosave');
     expect(other.ORIGINDATA).toEqual('origindata');

--- a/packages/core/src/constants/plugins.ts
+++ b/packages/core/src/constants/plugins.ts
@@ -7,7 +7,6 @@ export const MODELLOAD: PluginTypeI = 'modelLoad';
 export const MODELDEFINE: PluginTypeI = 'modelDefine';
 export const MODELTRAIN: PluginTypeI = 'modelTrain';
 export const MODELEVALUATE: PluginTypeI = 'modelEvaluate';
-export const MODELDEPLOY: PluginTypeI = 'modelDeploy';
 export const PLUGINS: PluginTypeI[] = [
   DATACOLLECT,
   DATAACCESS,
@@ -15,6 +14,5 @@ export const PLUGINS: PluginTypeI[] = [
   MODELLOAD,
   MODELDEFINE,
   MODELTRAIN,
-  MODELEVALUATE,
-  MODELDEPLOY
+  MODELEVALUATE
 ];

--- a/packages/core/src/constants/plugins_test.ts
+++ b/packages/core/src/constants/plugins_test.ts
@@ -4,8 +4,7 @@ import {
   DATAPROCESS,
   MODELLOAD,
   MODELTRAIN,
-  MODELEVALUATE,
-  MODELDEPLOY
+  MODELEVALUATE
 } from './plugins';
 
 describe('plugins constant', () => {
@@ -16,6 +15,5 @@ describe('plugins constant', () => {
     expect(MODELLOAD).toEqual('modelLoad');
     expect(MODELTRAIN).toEqual('modelTrain');
     expect(MODELEVALUATE).toEqual('modelEvaluate');
-    expect(MODELDEPLOY).toEqual('modelDeploy');
   });
 });

--- a/packages/core/src/runner/helper.ts
+++ b/packages/core/src/runner/helper.ts
@@ -10,7 +10,7 @@ import { PipcookComponentResult } from '../types/component';
 import { EvaluateError } from '../types/other';
 import { logCurrentExecution } from '../utils/logger';
 import { flatMap } from 'rxjs/operators';
-import { DATA, MODEL, EVALUATE, DEPLOYMENT, MODELTOSAVE } from '../constants/other';
+import { DATA, MODEL, EVALUATE, MODELTOSAVE } from '../constants/other';
 
 /**
  * Retreive relative logs required to be stored.
@@ -51,9 +51,6 @@ export async function assignLatestResult(updatedType: string, result: any, self:
     if (self.latestEvaluateResult.pass === false) {
       throw new EvaluateError(self.latestEvaluateResult);
     }
-    break;
-  case DEPLOYMENT:
-    self.latestDeploymentResult = result;
     break;
   case MODELTOSAVE:
     self.latestModel = result;

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -11,7 +11,7 @@ import config from '../config';
 import { PipcookComponentResult } from '../types/component';
 import { UniDataset } from '../types/data/common';
 import { UniModel } from '../types/model';
-import { DeploymentResult, EvaluateResult } from '../types/other';
+import { EvaluateResult } from '../types/other';
 import { getLog, createPipeline, assignLatestResult, linkComponents, assignFailures } from './helper';
 import { logStartExecution, logError, logComplete } from '../utils/logger';
 import { PLUGINS } from '../constants/plugins';
@@ -45,7 +45,6 @@ const getCircularReplacer = () => {
  * @public pipelineId: id for this time's execution
  * @public latestSampleData: up to date train data in the pipeline
  * @public latestModel: up to date model data in the pipeline
- * @public latestDeploymentResult: up to date deployment data in the pipeline
  * @public updatedType: the return type of lastest plugin in the pipeline
  * @public components: all components executed in the pipeline
  * @public currentIndex: lastest indes of components executed
@@ -63,7 +62,6 @@ export class PipcookRunner {
   latestSampleData: UniDataset |null = null;
   latestModel: UniModel |null = null;
   latestEvaluateResult: EvaluateResult | null = null;
-  latestDeploymentResult: DeploymentResult | null = null;
 
   updatedType: string | null = null;
   components: PipcookComponentResult[] = [];

--- a/packages/core/src/types/component.ts
+++ b/packages/core/src/types/component.ts
@@ -15,14 +15,13 @@ interface ObserverFunc<T extends PipcookPlugin> {
 }
 
 type ResultType = 
-  'dataCollect' | 
-  'dataAccess' | 
-  'dataProcess' | 
-  'modelLoad' | 
-  'modelDefine' |
-  'modelTrain' |
-  'modelEvaluate' |
-  'modelDeploy' ;
+  | 'dataCollect'
+  | 'dataAccess'
+  | 'dataProcess'
+  | 'modelLoad'
+  | 'modelDefine'
+  | 'modelTrain'
+  | 'modelEvaluate'
 
 export interface PipcookComponentResult<T extends PipcookPlugin = PipcookPlugin> {
   type: ResultType;

--- a/packages/core/src/types/other.ts
+++ b/packages/core/src/types/other.ts
@@ -3,13 +3,6 @@ export interface Statistic {
   metricValue: number;
 }
 
-export interface DeploymentResult {
-  version: string;
-  deployService: string;
-  serviceapi: string;
-  extraData: any;
-} 
-
 export type PipObject = Record<string, any>
 
 export interface EvaluateResult {

--- a/packages/core/src/types/plugins.ts
+++ b/packages/core/src/types/plugins.ts
@@ -4,7 +4,7 @@ import { UniModel } from './model';
 import { EvaluateResult } from './other';
 import { InsertParams } from './component';
 
-export type PluginTypeI = 'dataCollect' | 'dataAccess' | 'dataProcess' | 'modelLoad' | 'modelDefine' |'modelTrain' | 'modelEvaluate' | 'modelDeploy';
+export type PluginTypeI = 'dataCollect' | 'dataAccess' | 'dataProcess' | 'modelLoad' | 'modelDefine' |'modelTrain' | 'modelEvaluate';
 
 export type ArgsType = InsertParams & Record<string, any>
 


### PR DESCRIPTION
Deployment has been removed from plugins and packaged into the core(#117), but there are still some useless strategies or definitions of deploy plugin left, this PR will remove it