### PR TITLE
core: add type definition of the ouput type

### DIFF
--- a/packages/core/src/components/lifecycle.ts
+++ b/packages/core/src/components/lifecycle.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { from, range, forkJoin, Observable } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
 import { PipcookLifeCycleComponent, PipcookComponentResult, PipcookLifeCycleTypes } from '../types/component';
-import { DATA, MODEL, EVALUATE, MODELTOSAVE } from '../constants/other';
+import { OutputType } from '../constants/other';
 import {
   PipcookPlugin,
   DataCollectType,
@@ -42,7 +42,7 @@ function produceResultFactory<T extends PipcookPlugin>(type: PluginTypeI, plugin
     plugin,
     previousComponent: null,
     status: 'not execute',
-    returnType: 'not set'
+    returnType: OutputType.NotSet
   };
   if (params) {
     result.params = params;
@@ -73,7 +73,7 @@ export const DataAccess: PipcookLifeCycleComponent<DataAccessType> = (plugin, pa
   result.observer = (data, model, insertParams) => {
     return from(plugin({ ...params, ...insertParams }));
   };
-  result.returnType = DATA;
+  result.returnType = OutputType.Data;
   return result;
 };
 
@@ -115,7 +115,7 @@ export const ModelLoad: PipcookLifeCycleComponent<ModelLoadType> = (plugin, para
   result.observer = (data, model, insertParams) => {
     return from(plugin(data, { ...params, ...insertParams }));
   };
-  result.returnType = MODEL;
+  result.returnType = OutputType.Model;
   return result;
 };
 
@@ -129,7 +129,7 @@ export const ModelDefine: PipcookLifeCycleComponent<ModelDefineType> = (plugin, 
   result.observer = (data, model, insertParams) => {
     return from(plugin(data, { ...params, ...insertParams }));
   };
-  result.returnType = MODEL;
+  result.returnType = OutputType.Model;
   return result;
 };
 
@@ -148,7 +148,7 @@ export const ModelTrain: PipcookLifeCycleComponent<ModelTrainType> = (plugin, pa
       }
     }));
   };
-  result.returnType = MODELTOSAVE;
+  result.returnType = OutputType.ModelToSave;
   return result;
 };
 
@@ -162,7 +162,7 @@ export const ModelEvaluate: PipcookLifeCycleComponent<ModelEvaluateType> = (plug
   result.observer = (data, model, insertParams) => {
     return from(plugin(data, model, { ...params, ...insertParams }));
   };
-  result.returnType = EVALUATE;
+  result.returnType = OutputType.Evaluate;
   return result;
 };
 

--- a/packages/core/src/constants/other.ts
+++ b/packages/core/src/constants/other.ts
@@ -1,8 +1,3 @@
-export const STATUS_NOT_EXECUTE = 'not execute';
-export const STATUS_SUCCESS = 'success';
-export const STATUS_FAILURE = 'failure';
-export const STATUS_RUNNING = 'running';
-
 export const enum OutputType {
   Data = 'data',
   Model = 'model',

--- a/packages/core/src/constants/other.ts
+++ b/packages/core/src/constants/other.ts
@@ -3,9 +3,12 @@ export const STATUS_SUCCESS = 'success';
 export const STATUS_FAILURE = 'failure';
 export const STATUS_RUNNING = 'running';
 
-export const DATA = 'data';
-export const MODEL = 'model';
-export const EVALUATE = 'evaluate';
-export const MERGE = 'merge';
-export const MODELTOSAVE = 'modeltosave';
-export const ORIGINDATA = 'origindata';
+export const enum OutputType {
+  Data = 'data',
+  Model = 'model',
+  Evaluate = 'evaluate',
+  Merge = 'merge',
+  ModelToSave = 'modeltosave',
+  OriginData = 'origindata',
+  NotSet = 'not set'
+}

--- a/packages/core/src/constants/other_test.ts
+++ b/packages/core/src/constants/other_test.ts
@@ -1,14 +1,7 @@
-import * as other from './other';
-
-const { OutputType } = other;
+import { OutputType } from './other';
 
 describe('other constants', () => {
   it('should own some constants', () => {
-    expect(other.STATUS_NOT_EXECUTE).toEqual('not execute');
-    expect(other.STATUS_SUCCESS).toEqual('success');
-    expect(other.STATUS_FAILURE).toEqual('failure');
-    expect(other.STATUS_RUNNING).toEqual('running');
-
     expect(OutputType.Data).toEqual('data');
     expect(OutputType.Model).toEqual('model');
     expect(OutputType.Evaluate).toEqual('evaluate');

--- a/packages/core/src/constants/other_test.ts
+++ b/packages/core/src/constants/other_test.ts
@@ -1,5 +1,7 @@
 import * as other from './other';
 
+const { OutputType } = other;
+
 describe('other constants', () => {
   it('should own some constants', () => {
     expect(other.STATUS_NOT_EXECUTE).toEqual('not execute');
@@ -7,11 +9,11 @@ describe('other constants', () => {
     expect(other.STATUS_FAILURE).toEqual('failure');
     expect(other.STATUS_RUNNING).toEqual('running');
 
-    expect(other.DATA).toEqual('data');
-    expect(other.MODEL).toEqual('model');
-    expect(other.EVALUATE).toEqual('evaluate');
-    expect(other.MERGE).toEqual('merge');
-    expect(other.MODELTOSAVE).toEqual('modeltosave');
-    expect(other.ORIGINDATA).toEqual('origindata');
+    expect(OutputType.Data).toEqual('data');
+    expect(OutputType.Model).toEqual('model');
+    expect(OutputType.Evaluate).toEqual('evaluate');
+    expect(OutputType.Merge).toEqual('merge');
+    expect(OutputType.ModelToSave).toEqual('modeltosave');
+    expect(OutputType.OriginData).toEqual('origindata');
   });
 });

--- a/packages/core/src/runner/helper.ts
+++ b/packages/core/src/runner/helper.ts
@@ -7,7 +7,7 @@ import { from } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
 
 import { PipcookRunner } from './index';
-import { DATA, MODEL, EVALUATE, MODELTOSAVE } from '../constants/other';
+import { OutputType } from '../constants/other';
 import { logCurrentExecution } from '../utils/logger';
 import { PipcookComponentResult, InsertParams, PipcookComponentOperator, PipcookComponentOutput } from '../types/component';
 import { EvaluateError, EvaluateResult, PipObject } from '../types/other';
@@ -39,22 +39,22 @@ export function getLog(pipcookRunner: PipcookRunner) {
  * @param self: the target update runner
  * @param saveModelCallback
  */
-export async function assignLatestResult(updatedType: string, result: PipcookComponentOutput, self: PipcookRunner, saveModelCallback?: Function) {
+export async function assignLatestResult(updatedType: OutputType, result: PipcookComponentOutput, self: PipcookRunner, saveModelCallback?: Function) {
   switch (updatedType) {
-  case DATA:
+  case OutputType.Data:
     self.latestSampleData = result as UniDataset;
     break;
-  case MODEL:
+  case OutputType.Model:
     self.latestModel = result as UniModel;
     break;
-  case EVALUATE:
+  case OutputType.Evaluate:
     console.log('evaluate result: ', result);
     self.latestEvaluateResult = result as EvaluateResult;
     if (self.latestEvaluateResult.pass === false) {
       throw new EvaluateError(self.latestEvaluateResult);
     }
     break;
-  case MODELTOSAVE:
+  case OutputType.ModelToSave:
     self.latestModel = result as UniModel;
     if (saveModelCallback) {
       const valueMap = 

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -24,6 +24,7 @@ import {
   MODELDEFINE
 } from '../constants/plugins';
 import { LifeCycleTypes } from '../components/lifecycle';
+import { OutputType } from '../constants/other';
 
 const getCircularReplacer = () => {
   const seen = new WeakSet();
@@ -63,7 +64,7 @@ export class PipcookRunner {
   latestModel: UniModel |null = null;
   latestEvaluateResult: EvaluateResult | null = null;
 
-  updatedType: string | null = null;
+  updatedType: OutputType = null;
   components: PipcookComponentResult[] = [];
   currentIndex = -1;
   error: string = null;

--- a/packages/core/src/types/component.ts
+++ b/packages/core/src/types/component.ts
@@ -3,6 +3,7 @@ import { PipcookPlugin, PluginTypeI } from './plugins';
 import { UniModel } from './model';
 import { UniDataset } from './data/common';
 import { PipObject, PromisedValueOf, EvaluateResult } from './other';
+import { OutputType } from '../constants/other';
 
 export interface InsertParams {
   pipelineId: string;
@@ -28,7 +29,7 @@ export interface PipcookComponentResult<T extends PipcookPlugin = PipcookPlugin>
   mergeComponents?: PipcookComponentResult<T>[][];
   params?: PipObject;
   observer?: ObserverFunc<T>;
-  returnType?: string;
+  returnType?: OutputType;
   previousComponent: PipcookComponentResult<T> | null;
   status: 'not execute' | 'running' | 'success' | 'failure';
   package?: string;


### PR DESCRIPTION
This PR improves the type of `updateType` that mentioned at #177 
- Adding type definition of the output type
- remove useless status constants