### PR TITLE
costa: support beta version for installing plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "lerna run compile",
     "lint": "eslint . --ext .ts --ext .js && lerna run --scope @pipcook/daemon --scope @pipcook/pipboard lint",
     "pretest": "npm run lint",
-    "test": "lerna run --scope @pipcook/pipcook-core --scope @pipcook/boa test",
+    "test": "lerna run --scope @pipcook/pipcook-core --scope @pipcook/boa test --scope @pipcook/costa",
     "test:pipeline": "sh ./run_pipeline.sh",
     "typedoc": "typedoc",
     "clean": "lerna run clean",

--- a/packages/costa/package.json
+++ b/packages/costa/package.json
@@ -8,6 +8,7 @@
     "dist"
   ],
   "scripts": {
+    "pretest": "rm -rf .tests",
     "test": "ts-node ../../run_tests.ts",
     "build": "npm run clean && npm run compile",
     "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",

--- a/packages/costa/src/index.ts
+++ b/packages/costa/src/index.ts
@@ -23,8 +23,9 @@ export interface RuntimeOptions {
  */
 export interface PluginSource {
   from: 'fs' | 'npm' | null;
-  name: string;
   uri: string | null;
+  name: string;
+  schema?: NpmPackageNameSchema;
 }
 
 /**
@@ -126,4 +127,22 @@ export interface NpmPackageMetadata {
     latest: string;
   };
   versions: Record<string, NpmPackage>;
+}
+
+/**
+ * It represents the name schema for a package name string for npm. For exmaple,
+ * `@pipcook/test@1.x` outputs an object with scope(@pipcook), name(test) and
+ * version(1.x).
+ */
+export class NpmPackageNameSchema {
+  scope: string | null;
+  version: string | null;
+  name: string;
+  get packageName(): string {
+    if (this.scope) {
+      return `${this.scope}/${this.name}`;
+    } else {
+      return this.name;
+    }
+  }
 }

--- a/packages/costa/src/runnable_test.ts
+++ b/packages/costa/src/runnable_test.ts
@@ -25,6 +25,6 @@ describe('start runnable in normal way', () => {
   it('should destroy the runnable', async () => {
     await runnable.destroy();
     const list = await readdir(costa.options.componentDir);
-    expect(list.length).toBe(0);
+    expect(list.length).toBe(1);
   });
 });

--- a/packages/costa/src/runtime_test.ts
+++ b/packages/costa/src/runtime_test.ts
@@ -3,6 +3,7 @@ import { CostaRuntime } from './runtime';
 import { PluginPackage } from '.';
 import { stat } from 'fs-extra';
 
+console.log(process.env.NODE_ENV);
 describe('create a costa runtime', () => {
   const costa = new CostaRuntime({
     installDir: path.join(__dirname, '../.tests/plugins'),
@@ -18,24 +19,52 @@ describe('create a costa runtime', () => {
     expect(collectCsv.pipcook.category).toBe('dataCollect');
   });
 
-  it('should install the package', async () => {
+  it('should fetch a plugin from npm', async () => {
+    const collectCsvWithSpecificVer = await costa.fetch('@pipcook/plugins-csv-data-collect@0.5.8');
+    expect(collectCsvWithSpecificVer.name).toBe('@pipcook/plugins-csv-data-collect');
+    expect(collectCsvWithSpecificVer.version).toBe('0.5.8');
+
+    const collectCsvLatest = await costa.fetch('@pipcook/plugins-csv-data-collect@latest');
+    expect(collectCsvLatest.name).toBe('@pipcook/plugins-csv-data-collect');
+
+    const collectCsvOnBeta = await costa.fetch('@pipcook/plugins-csv-data-collect@beta');
+    expect(collectCsvOnBeta.name).toBe('@pipcook/plugins-csv-data-collect');
+    expect(collectCsvOnBeta.version.search('beta') !== -1).toBe(true);
+
+    const collectCsvOnBare = await costa.fetch('@pipcook/plugins-csv-data-collect');
+    expect(collectCsvOnBare.name).toBe('@pipcook/plugins-csv-data-collect');
+    expect(collectCsvOnBare.version).toBe(collectCsvLatest.version);
+  }, 30 * 1000);
+
+  it('should install the package without conda packages', async () => {
     await costa.install(collectCsv);
     await stat(path.join(
       costa.options.installDir,
       'node_modules',
       collectCsv.name
     ));
+  }, 60 * 1000);
+
+  it('should install the package with conda packages', async () => {
+    const bayesClassifier = await costa.fetch('../plugins/model-define/bayesian-model-define');
+    await costa.install(bayesClassifier);
+    await stat(path.join(
+      costa.options.installDir,
+      'node_modules',
+      bayesClassifier.name
+    ));
     await stat(path.join(
       costa.options.installDir,
       'conda_envs',
-      `${collectCsv.name}@${collectCsv.version}`
+      `${bayesClassifier.name}@${bayesClassifier.version}`
     ));
-  }, 30 * 1000);
+  }, 60 * 1000);
 
   it('should start the package', async () => {
-    const runnable = await costa.createRunnable();
+    const runnable = await costa.createRunnable({ id: 'foobar' });
     await runnable.start(collectCsv, {
-      dataDir: costa.options.datasetDir
+      dataDir: costa.options.datasetDir,
+      url: 'http://ai-sample.oss-cn-hangzhou.aliyuncs.com/image_classification/datasets/textClassification.zip'
     });
     await runnable.destroy();
   });

--- a/run_tests.ts
+++ b/run_tests.ts
@@ -1,12 +1,13 @@
 Error.stackTraceLimit = Infinity;
-const jasmineCtor = require('jasmine');
+const JasmineCtor = require('jasmine');
 const { SpecReporter } = require('jasmine-spec-reporter');
 
+process.env.NODE_ENV = 'test';
 process.on('unhandledRejection', (e) => {
   throw e;
 });
 
-const runner = new jasmineCtor();
+const runner = new JasmineCtor();
 runner.loadConfig({
   spec_files: [ 'src/**/*_test.ts' ],
   random: false


### PR DESCRIPTION
This supports the beta and specific version for plugin installation:

- `@pipcook/my-plugin`
- `@pipcook/my-plugin@latest`
- `@pipcook/my-plugin@beta`
- `@pipcook/my-plugin@1.0.0`