### PR TITLE
boa: share the cpython instance globally

### DIFF
--- a/packages/boa/lib/index.js
+++ b/packages/boa/lib/index.js
@@ -10,8 +10,13 @@ const DelegatorLoader = require('./delegator-loader');
 // internal symbols
 const IterIdxForSeqSymbol = Symbol('The iteration index for sequence');
 
-// create the instance
-let pyInst = new native.Python(process.argv.slice(1));
+// create the global-scoped instance
+let pyInst = global.__pipcook_boa_pyinst__;
+if (pyInst == null) {
+  pyInst = new native.Python(process.argv.slice(1));
+  global.__pipcook_boa_pyinst__ = pyInst;
+}
+
 const importedNames = [];
 // FIXME(Yorkie): move to costa or daemon?
 const sharedModules = ['sys', 'torch'];

--- a/packages/boa/package.json
+++ b/packages/boa/package.json
@@ -4,7 +4,6 @@
   "description": "Use Python modules seamlessly in Node.js",
   "main": "lib/index.js",
   "scripts": {
-    "clean": "rm -rf ./build && rm -rf ./node_modules",
     "preinstall": "node tools/install-python.js && node tools/install-requirements.js",
     "clean": "sh tools/clean-python.sh",
     "postinstall": "npm run build",


### PR DESCRIPTION
The CPython is a single instance, so we need to keep consistent with CPython by storing its instance globally.

This fixes the issue "python interrupter is already running" when loading the boa in different plugins.