### PR TITLE
costa: support install plugin from git(ssh)

### DIFF
--- a/docs/manual/pipcook-tools.md
+++ b/docs/manual/pipcook-tools.md
@@ -134,6 +134,12 @@ Install a new plugin from a local path
 $ pipcook plugin install /path/to/dir/of/your/plugin
 ```
 
+Install a new plugin from git via ssh
+
+```sh
+$ pipcook plugin install git+ssh://git@some.git.com/my-git-repo.git
+```
+
 Note: when installing a plugin, you must ensure that this package of plugin complies with our plugin specification.
 
 ## Daemon Management

--- a/docs/zh-cn/manual/pipcook-tools.md
+++ b/docs/zh-cn/manual/pipcook-tools.md
@@ -134,6 +134,12 @@ $ pipcook plugin install @pipcook/plugins-csv-data-access
 $ pipcook plugin install /path/to/dir/of/your/plugin
 ```
 
+从 Git 安装
+
+```sh
+$ pipcook plugin install git+ssh://git@some.git.com/my-git-repo.git
+```
+
 注意：在安装插件时，必须保证安装的插件符合 Pipcook 插件规范。
 
 ## 服务管理

--- a/packages/costa/package.json
+++ b/packages/costa/package.json
@@ -28,6 +28,7 @@
     "fs-extra": "^8.1.0",
     "request": "^2.88.2",
     "request-promise": "^4.2.5",
+    "tar-stream": "^2.1.2",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/packages/costa/src/index.ts
+++ b/packages/costa/src/index.ts
@@ -1,3 +1,4 @@
+import * as url from 'url';
 import { PluginTypeI } from '@pipcook/pipcook-core';
 
 /**
@@ -22,8 +23,9 @@ export interface RuntimeOptions {
  * This represents a source of a plugin.
  */
 export interface PluginSource {
-  from: 'fs' | 'npm' | null;
+  from: 'fs' | 'npm' | 'git' | null;
   uri: string | null;
+  urlObject: url.UrlWithStringQuery;
   name: string;
   schema?: NpmPackageNameSchema;
 }

--- a/packages/costa/src/runtime.ts
+++ b/packages/costa/src/runtime.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 import url from 'url';
 import { ensureDir, ensureDirSync, pathExists, remove, writeFile, readFile, access } from 'fs-extra';
-import { spawn, SpawnOptions } from 'child_process';
+import tar from 'tar-stream';
+import { spawn, SpawnOptions, ChildProcess } from 'child_process';
 import { PluginRunnable, BootstrapArg } from './runnable';
 import {
   NpmPackageMetadata,
@@ -44,6 +45,35 @@ function spawnAsync(command: string, args?: string[], opts: SpawnOptions = {}): 
     child.on('close', (code: number) => {
       code === 0 ? resolve() : reject(new TypeError(`invalid code ${code} from ${command}`));
     });
+  });
+}
+
+function fetchPackageJsonFromGit(remote: string, head: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let packageJson = '';
+    const extract = tar.extract();
+    extract.on('entry', (header, stream, next) => {
+      if (header.name === 'package.json') {
+        stream.on('data', (buf) => packageJson += buf);
+      }
+      stream.once('end', next);
+      stream.resume();
+    });
+    extract.on('finish', () => {
+      try {
+        resolve(JSON.parse(packageJson));
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    const child = spawn('git', [
+      'archive',
+      `--remote=${remote}`,
+      head,
+      'package.json'
+    ]);
+    child.stdout.pipe(extract);
   });
 }
 
@@ -99,7 +129,11 @@ export class CostaRuntime {
       const resp = await request(source.uri);
       const meta = JSON.parse(resp) as NpmPackageMetadata;
       pkg = selectNpmPackage(meta, source);
-    } else {
+    } else if (source.from === 'git') {
+      debug(`requesting the url ${source.uri}...`);
+      const { hostname, pathname } = source.urlObject;
+      pkg = await fetchPackageJsonFromGit(`git@${hostname}:${pathname}`, 'HEAD');
+    } else if (source.from === 'fs') {
       debug(`linking the url ${source.uri}`);
       pkg = require(`${source.uri}/package.json`);
     }
@@ -144,7 +178,7 @@ export class CostaRuntime {
       debug(`install the plugin from npm registry: ${pluginAbsName}`);
     } else {
       pluginAbsName = pkg.pipcook.source.uri;
-      debug(`install the plugin from local: ${pluginAbsName}`);
+      debug(`install the plugin from ${pluginAbsName}`);
     }
 
     const npmExecOpts = { cwd: this.options.installDir };
@@ -153,7 +187,7 @@ export class CostaRuntime {
       await spawnAsync('npm', [ 'init', '-y' ], npmExecOpts);
       await spawnAsync('npm', [ 'install', boaSrcPath, '-E' ], npmExecOpts);
     }
-    await spawnAsync('npm', [ 'install', `${pluginAbsName}`, '-E', '--production' ], npmExecOpts);
+    await spawnAsync('npm', [ 'install', `${pluginAbsName}`, '-E', '--production', '--verbose' ], npmExecOpts);
 
     if (pkg.conda?.dependencies) {
       debug(`prepare the Python environment for ${pluginStdName}`);
@@ -264,10 +298,15 @@ export class CostaRuntime {
     const src: PluginSource = {
       from: null,
       name,
-      uri: null
+      uri: null,
+      urlObject: urlObj
     };
     if (path.isAbsolute(name)) {
       src.from = 'fs';
+      src.uri = name;
+    } else if (/^git(\+ssh)?:$/.test(urlObj.protocol)) {
+      const { host, pathname } = urlObj;
+      src.from = 'git';
       src.uri = name;
     } else if (name[0] !== '.') {
       src.schema = this.getNameSchema(name);

--- a/packages/costa/src/runtime.ts
+++ b/packages/costa/src/runtime.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import url from 'url';
 import { ensureDir, ensureDirSync, pathExists, remove, writeFile, readFile, access } from 'fs-extra';
 import tar from 'tar-stream';
-import { spawn, SpawnOptions, ChildProcess } from 'child_process';
+import { spawn, SpawnOptions } from 'child_process';
 import { PluginRunnable, BootstrapArg } from './runnable';
 import {
   NpmPackageMetadata,


### PR DESCRIPTION
Installing a plugin from git via ssh is an easy way to share plugins, now we could install the plugin and write pipeline in the following way:

```
{
  "plugins": {
    "dataCollect": {
      "package": "git+ssh://git@gitlab.com/repo.git"
    }
  }
}
```