### PR TITLE
costa: add dependency @type/tar-stream

### DIFF
--- a/packages/costa/package.json
+++ b/packages/costa/package.json
@@ -23,6 +23,7 @@
     "@types/request": "^2.48.4",
     "@types/request-promise": "^4.1.46",
     "@types/uuid": "^7.0.2",
+    "@types/tar-stream": "^2.1.0",
     "better-opn": "^1.0.0",
     "debug": "^4.1.1",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
There is a build error here:
``` shell
src/runtime.ts:4:17 - error TS7016: Could not find a declaration file for module 'tar-stream'. 'pipcook/packages/costa/node_modules/tar-stream/index.js' implicitly has an 'any' type.
  Try `npm install @types/tar-stream` if it exists or add a new declaration (.d.ts) file containing `declare module 'tar-stream';`
```