### PR TITLE
modify dockerfile and data collect

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,14 +2,11 @@ FROM centos/nodejs-12-centos7:latest
 LABEL version=1.1
 LABEL description="docker image for pipcook runtime"
 
-COPY --from=nvidia/cuda:10.0-cudnn7-runtime /usr/local/cuda-10.0 /usr/local/cuda-10.0
+COPY --from=nvidia/cuda:10.2-cudnn7-runtime /usr/local/cuda-10.2 /usr/local/cuda-10.2
 COPY --from=nvidia/cuda:10.1-cudnn7-runtime /usr/local/cuda-10.1 /usr/local/cuda-10.1
 
 ENV TF_FORCE_GPU_ALLOW_GROWTH=true
-ENV LD_LIBRARY_PATH=/usr/local/cuda-10.0/lib64:/usr/local/cuda-10.1/lib64:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64:/usr/local/cuda-10.2/lib64:${LD_LIBRARY_PATH}
 
 WORKDIR /opt/pipcook
 RUN npm install @pipcook/pipcook-cli -g  && pipcook init
-RUN pipcook pipeline install https://raw.githubusercontent.com/alibaba/pipcook/master/example/pipelines/databinding-image-classification.json
-RUN pipcook pipeline install https://raw.githubusercontent.com/alibaba/pipcook/master/example/pipelines/object-detection.json
-RUN pipcook pipeline install https://raw.githubusercontent.com/alibaba/pipcook/master/example/pipelines/text-bayes-classification.json

--- a/packages/plugins/data-collect/csv-data-collect/package.json
+++ b/packages/plugins/data-collect/csv-data-collect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipcook/plugins-csv-data-collect",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/plugins/data-collect/csv-data-collect/src/index.ts
+++ b/packages/plugins/data-collect/csv-data-collect/src/index.ts
@@ -28,6 +28,9 @@ const textClassDataCollect: DataCollectType = async (args: ArgsType): Promise<vo
     dataDir
   } = args;
 
+  await fs.remove(dataDir);
+  await fs.ensureDir(dataDir);
+  
   assert.ok(url, 'Please specify a url of zip of your data');
 
   const fileName = url.split(path.sep)[url.split(path.sep).length - 1];

--- a/packages/plugins/data-collect/csv-data-collect/src/index.ts
+++ b/packages/plugins/data-collect/csv-data-collect/src/index.ts
@@ -30,7 +30,7 @@ const textClassDataCollect: DataCollectType = async (args: ArgsType): Promise<vo
 
   await fs.remove(dataDir);
   await fs.ensureDir(dataDir);
-  
+
   assert.ok(url, 'Please specify a url of zip of your data');
 
   const fileName = url.split(path.sep)[url.split(path.sep).length - 1];

--- a/packages/plugins/data-collect/image-classification-data-collect/package.json
+++ b/packages/plugins/data-collect/image-classification-data-collect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipcook/plugins-image-classification-data-collect",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/plugins/data-collect/image-classification-data-collect/src/index.ts
+++ b/packages/plugins/data-collect/image-classification-data-collect/src/index.ts
@@ -34,6 +34,9 @@ const imageClassDataCollect: DataCollectType = async (args: ArgsType): Promise<v
     dataDir
   } = args;
 
+  await fs.remove(dataDir);
+  await fs.ensureDir(dataDir);
+
   assert.ok(url, 'Please specify the url of your dataset');
 
   const fileName = url.split(path.sep)[url.split(path.sep).length - 1];

--- a/packages/plugins/data-collect/mnist-data-collect/package.json
+++ b/packages/plugins/data-collect/mnist-data-collect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipcook/plugins-mnist-data-collect",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "",
   "main": "dist/index",
   "types": "dist/index",
@@ -20,11 +20,13 @@
     "@tensorflow/tfjs-node-gpu": "1.7.0",
     "@types/cli-progress": "^3.4.2",
     "cli-progress": "^3.6.0",
+    "fs-extra": "^8.1.0",
     "jimp": "^0.10.0",
     "mnist": "^1.1.0"
   },
   "gitHead": "53e131a069b3112a74ae5d99aa1ab08bec768c7e",
   "devDependencies": {
+    "@types/fs-extra": "^8.1.0",
     "@types/jasmine": "^3.5.7",
     "nyc": "14.1.1"
   },

--- a/packages/plugins/data-collect/mnist-data-collect/src/index.ts
+++ b/packages/plugins/data-collect/mnist-data-collect/src/index.ts
@@ -3,6 +3,7 @@
  */
 import { DataCollectType, ArgsType, createAnnotationFile } from '@pipcook/pipcook-core';
 import * as tf from '@tensorflow/tfjs-node-gpu';
+import * as fs from 'fs-extra';
 import Jimp from 'jimp';
 import * as path from 'path';
 import _cliProgress from 'cli-progress';
@@ -18,6 +19,9 @@ const imageMnistDataCollect: DataCollectType = async (args: ArgsType): Promise<v
     testCount = 500,
     dataDir
   } = args;
+
+  await fs.remove(dataDir);
+  await fs.ensureDir(dataDir);
 
   const set = mnist.set(trainCount, testCount);
   const trainingSet = set.training;

--- a/packages/plugins/data-collect/object-detection-pascolvoc-data-collect/package.json
+++ b/packages/plugins/data-collect/object-detection-pascolvoc-data-collect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipcook/plugins-object-detection-pascalvoc-data-collect",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/plugins/data-collect/object-detection-pascolvoc-data-collect/src/index.ts
+++ b/packages/plugins/data-collect/object-detection-pascolvoc-data-collect/src/index.ts
@@ -9,6 +9,9 @@ const imageDetectionDataCollect: DataCollectType = async (args: ArgsType): Promi
     dataDir
   } = args;
 
+  await fs.remove(dataDir);
+  await fs.ensureDir(dataDir);
+
   assert.ok(url, 'Please specify a url of zip of your dataset');
 
   const fileName = url.split(path.sep)[url.split(path.sep).length - 1];


### PR DESCRIPTION
This PR includes:
1. Currently in data collect plugins, we do not clear the data folder, which results in mixture of different datasets. We can firstly remove folder for now. In the future, the data-collect plugin should be responsible for checking if the dataset url is changed or if the data content is changes and decide whether just ignore current dataset or download new one.

2. We need cuda 10.1 and cuda 10.2 in dockerfile. not 10.0 and 10.1