### PR TITLE
pipboard: simplify the pipboard list view

### DIFF
--- a/packages/daemon/src/service/pipeline.ts
+++ b/packages/daemon/src/service/pipeline.ts
@@ -85,6 +85,11 @@ export class PipelineService {
       limit,
       order: [
         [ 'createdAt', 'DESC' ]
+      ],
+      include: [
+        {
+          all: true
+        }
       ]
     });
   }

--- a/packages/pipboard/src/layouts/BasicLayout/index.jsx
+++ b/packages/pipboard/src/layouts/BasicLayout/index.jsx
@@ -17,8 +17,6 @@ export default class Dashboard extends Component {
   }
   
   render() {
-    console.log(location.hash);
-
     return (
       <div className="dashboard">
         <Nav className="basic-nav"

--- a/packages/pipboard/src/layouts/BasicLayout/index.jsx
+++ b/packages/pipboard/src/layouts/BasicLayout/index.jsx
@@ -6,7 +6,9 @@ import './index.scss';
 
 const { Item } = Nav;
 
-const header = <span className="header">pipcook</span>;
+const header = <a href="/index.html" style={{ color: '#000' }}>
+  <span className="header">PipBoard</span>
+</a>;
 
 export default class Dashboard extends Component {
 
@@ -15,16 +17,24 @@ export default class Dashboard extends Component {
   }
   
   render() {
+    console.log(location.hash);
+
     return (
       <div className="dashboard">
-        <Nav className="basic-nav" onSelect={this.select} direction="hoz" type="primary" header={header} selectedKeys={[]} triggerType="hover">
-          <Item key="home">Home</Item>
+        <Nav className="basic-nav"
+          onSelect={this.select}
+          direction="hoz"
+          hozAlign="left"
+          activeDirection="top"
+          type="normal"
+          header={header}
+          selectedKeys={[location.hash.replace(/#\//, '') || 'home']}
+          triggerType="hover">
           <Item key="pipeline">Pipelines</Item>
           <Item key="jobs">Jobs</Item>
         </Nav> 
         {this.props.children}
       </div>
-      
     );
   }
 }

--- a/packages/pipboard/src/layouts/BasicLayout/index.scss
+++ b/packages/pipboard/src/layouts/BasicLayout/index.scss
@@ -10,14 +10,14 @@
   height: 100%;
   padding-top: 45px;
   .basic-nav {
-    position: absolute;
+    position: fixed;
     top: 0;
     width: 100%;
     height: 45px;
+    z-index: 10;
     .header {
       margin: 8px 20px;
       width: 100px;
-      color: #FFFFFF;
       font-size: 20px;
     }
   } 

--- a/packages/pipboard/src/pages/Pipeline/index.jsx
+++ b/packages/pipboard/src/pages/Pipeline/index.jsx
@@ -67,7 +67,7 @@ export default class Pipeline extends Component {
       <div className="pipeline">
         <Table dataSource={models}
           hasBorder={false}
-          stickyHeader={true}
+          stickyHeader
           offsetTop={45}>
           {
             fields.map(field => <Table.Column 

--- a/packages/pipboard/src/pages/Pipeline/index.jsx
+++ b/packages/pipboard/src/pages/Pipeline/index.jsx
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
-import { Table, Pagination, Button } from '@alifd/next';
+import { Table, Pagination, Button, Icon } from '@alifd/next';
 
-import {messageError} from '@/utils/message';
+import { messageError } from '@/utils/message';
 import { PIPELINE_MAP, JOB_MAP, PIPELINE_STATUS } from '@/utils/config';
 import { get } from '@/utils/request';
 
 import './index.scss';
 
-const PAGE_SIZE = 10; // number of records in one page
+const PAGE_SIZE = 30; // number of records in one page
 
 export default class Pipeline extends Component {
 
@@ -61,23 +61,20 @@ export default class Pipeline extends Component {
     await this.fetchData(1);
   }
 
-  renderDetail = (value, index, record) => {
-    return <a href={`/index.html#/pipeline/info?pipelineId=${record.id}`}>
-      <Button>Detail</Button>
-    </a>;
-  }
-
   render() {
     const { models, fields, currentPage, totalCount } = this.state;
     return (
       <div className="pipeline">
-        <Table dataSource={models}>
+        <Table dataSource={models} hasBorder={false} stickyHeader={true} offsetTop={45}>
           {
             fields.map(field => <Table.Column 
               key={field.name}
               title={field.name}
               dataIndex={field.field}
               cell={field.cell}
+              sortable={field.sortable || false}
+              width={field.width}
+              align="center"
             />)
           }
         </Table>
@@ -85,15 +82,12 @@ export default class Pipeline extends Component {
           current={currentPage} 
           total={totalCount} 
           pageSize={PAGE_SIZE} 
+          type="simple"
           className="pagination-wrapper" 
-          onChange={this.changePage} 
+          onChange={this.changePage}
         />
         <div className="pipeline-create-container" onClick={() => location.href = 'index.html#/pipeline/info'}>
-          <img
-            className="pipeline-create" 
-            src="https://img.alicdn.com/tfs/TB1nTmRbmRLWu4jSZKPXXb6BpXa-128-128.png" 
-            alt="create pipeline"
-          />
+          <Icon className="pipeline-create" type="add" size="large" />
         </div>
       </div>
     );

--- a/packages/pipboard/src/pages/Pipeline/index.jsx
+++ b/packages/pipboard/src/pages/Pipeline/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Table, Pagination, Button, Icon } from '@alifd/next';
+import { Table, Pagination, Icon } from '@alifd/next';
 
 import { messageError } from '@/utils/message';
 import { PIPELINE_MAP, JOB_MAP, PIPELINE_STATUS } from '@/utils/config';
@@ -65,7 +65,10 @@ export default class Pipeline extends Component {
     const { models, fields, currentPage, totalCount } = this.state;
     return (
       <div className="pipeline">
-        <Table dataSource={models} hasBorder={false} stickyHeader={true} offsetTop={45}>
+        <Table dataSource={models}
+          hasBorder={false}
+          stickyHeader={true}
+          offsetTop={45}>
           {
             fields.map(field => <Table.Column 
               key={field.name}

--- a/packages/pipboard/src/pages/Pipeline/index.scss
+++ b/packages/pipboard/src/pages/Pipeline/index.scss
@@ -3,11 +3,15 @@
     position: fixed;
     right: 40px;
     bottom: 40px;
-    background-color: white;
     
     .pipeline-create {
-      width: 64px;
-      height: 64px;
+      background-color: #fff;
+      border-radius: 64px;
+      padding: 5px;
+      box-shadow: 1px 1px 5px #e3e3e3;
+      height: 40px;
+      width: 40px;
+      text-align: center;
     }
   }
 

--- a/packages/pipboard/src/utils/config.js
+++ b/packages/pipboard/src/utils/config.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Dialog } from '@alifd/next';
+import { Button, Dialog, Tag, Icon } from '@alifd/next';
 
 /**
  * !important: This File contains many information that should be returned by backend. For now, just remain these.
@@ -27,87 +27,104 @@ export const PIPELINE_STATUS = ['INIT', 'RUNNING', 'SUCCESS', 'FAIL'];
 
 export const PIPELINE_MAP = [
   {
-    name: 'Pipeline Id',
-    field: 'id',
+    name: 'ID',
+    width: 50,
+    cell: (value, index, record) => {
+      return <a href={`/index.html#/pipeline/info?pipelineId=${record.id}`}>
+        {record.id.replace(/-/g, '').slice(0, 12)}
+      </a>;
+    },
   },
   {
-    name: 'Data Collect',
-    field: 'dataCollect',
+    name: 'Dataset',
+    width: 100,
+    cell: (value, index, record) => {
+      return <Tag size="small" type="normal">{record.dataCollect}</Tag>;
+    },
   },
   {
-    name: 'Data Access',
-    field: 'dataAccess',
+    name: 'Model',
+    width: 100,
+    cell: (value, index, record) => {
+      return <Tag size="small" type="normal">{record.modelDefine}</Tag>;
+    },
   },
   {
-    name: 'Data Process',
-    field: 'dataProcess',
-  },
-  {
-    name: 'Model Define',
-    field: 'modelDefine',
-  },
-  {
-    name: 'Model Load',
-    field: 'modelLoad',
-  },
-  {
-    name: 'Model Train',
-    field: 'modelTrain',
-  },
-  {
-    name: 'Model Evaluate',
-    field: 'modelEvaluate',
+    name: 'Jobs',
+    cell: (value, index, record) => {
+      return <span>{record.jobs.length}</span>;
+    },
+    width: 30,
   },
   {
     name: 'Created At',
     field: 'createdAt',
-  },
-  {
-    name: 'Detail',
-    cell: (value, index, record) => {
-      return <a href={`/index.html#/pipeline/info?pipelineId=${record.id}`}><Button>Detail</Button></a>;
-    },
+    width: 50,
+    sortable: true
   },
 ];
 
 export const JOB_MAP = [
   {
-    name: 'Job Id',
-    field: 'id',
-  },
-  {
-    name: 'Status',
-    field: 'status',
-  },
-  {
-    name: 'Evaluate Pass',
+    name: 'ID',
+    width: 50,
     cell: (value, index, record) => {
-      return record.evaluateMap ? <Button onClick={
-        () => {Dialog.show({title: 'evaluate pass', content: record.evaluateMap});}
-      }>Check</Button> : 'no evaluateMap';
+      return <a href={`/index.html#/pipeline/info?pipelineId=${record.pipelineId}&jobId=${record.id}`}>
+        {record.id.replace(/-/g, '').slice(0, 12)}
+      </a>;
     },
   },
   {
-    name: 'Spec Version',
-    field: 'specVersion',
+    name: 'Status',
+    width: 50,
+    cell: (value, index, record) => {
+      const colors = {
+        INIT: 'yellow',
+        RUNNING: 'yellow',
+        SUCCESS: 'green',
+        FAIL: 'red'
+      };
+      return <Tag size="small" color={colors[record.status]}>{record.status}</Tag>;
+    },
   },
   {
-    name: 'Error',
+    name: 'Result',
+    width: 100,
     cell: (value, index, record) => {
-      return record.error ? <Button onClick={
-        () => {Dialog.show({title: 'error', content: record.error});}
-      }>Check</Button> : 'no error';
+      let result = null;
+      if (record.evaluateMap) {
+        result = JSON.parse(record.evaluateMap);
+        result.pass = undefined;
+      } else {
+        return <span>no result</span>;
+      }
+      if (record.evaluatePass) {
+        const content = JSON.stringify(result, null, 2);
+        const onClick = () => {
+          Dialog.show({
+            title: 'evaluation',
+            content
+          });
+        };
+        return <Button size="small" onClick={onClick}>{content.slice(0, 40)}</Button>;
+      } else {
+        return <Tag size="small" color="red">{record.error}</Tag>;
+      }
+    },
+  },
+  {
+    name: 'Pipeline',
+    width: 50,
+    cell: (value, index, record) => {
+      return <a href={`/index.html#/pipeline/info?pipelineId=${record.pipelineId}`}>
+        {record.id.replace(/-/g, '').slice(0, 12)}
+      </a>;
     },
   },
   {
     name: 'End Time',
+    width: 100,
     field: 'endTime',
-  },
-  {
-    name: 'Check Pipeline',
-    cell: (value, index, record) => {
-      return <a href={`/index.html#/pipeline/info?pipelineId=${record.pipelineId}&jobId=${record.id}`}><Button>Detail</Button></a>;
-    },
   },
 ];
 

--- a/packages/pipboard/src/utils/config.js
+++ b/packages/pipboard/src/utils/config.js
@@ -88,7 +88,7 @@ export const JOB_MAP = [
     },
   },
   {
-    name: 'Result',
+    name: 'Evaluation',
     width: 100,
     cell: (value, index, record) => {
       let result = null;
@@ -125,6 +125,16 @@ export const JOB_MAP = [
     name: 'End Time',
     width: 100,
     field: 'endTime',
+  },
+  {
+    name: 'Model',
+    width: 40,
+    cell: (value, index, record) => {
+      const download = () => {
+        location.href = `/job/${record.id}/output.tar.gz`;
+      };
+      return <Button size="small" disabled={record.status !== 'SUCCESS'} onClick={download}>Download</Button>
+    }
   },
 ];
 

--- a/packages/pipboard/src/utils/config.js
+++ b/packages/pipboard/src/utils/config.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Dialog, Tag, Icon } from '@alifd/next';
+import { Button, Dialog, Tag } from '@alifd/next';
 
 /**
  * !important: This File contains many information that should be returned by backend. For now, just remain these.
@@ -60,7 +60,7 @@ export const PIPELINE_MAP = [
     name: 'Created At',
     field: 'createdAt',
     width: 50,
-    sortable: true
+    sortable: true,
   },
 ];
 
@@ -82,7 +82,7 @@ export const JOB_MAP = [
         INIT: 'yellow',
         RUNNING: 'yellow',
         SUCCESS: 'green',
-        FAIL: 'red'
+        FAIL: 'red',
       };
       return <Tag size="small" color={colors[record.status]}>{record.status}</Tag>;
     },
@@ -103,7 +103,7 @@ export const JOB_MAP = [
         const onClick = () => {
           Dialog.show({
             title: 'evaluation',
-            content
+            content,
           });
         };
         return <Button size="small" onClick={onClick}>{content.slice(0, 40)}</Button>;
@@ -133,8 +133,8 @@ export const JOB_MAP = [
       const download = () => {
         location.href = `/job/${record.id}/output.tar.gz`;
       };
-      return <Button size="small" disabled={record.status !== 'SUCCESS'} onClick={download}>Download</Button>
-    }
+      return <Button size="small" disabled={record.status !== 'SUCCESS'} onClick={download}>Download</Button>;
+    },
   },
 ];
 


### PR DESCRIPTION
For Pipeline View:

<img width="1439" alt="Screen Shot 2020-06-19 at 7 35 00 PM" src="https://user-images.githubusercontent.com/1935767/85128536-12cb2b80-b264-11ea-922b-8b39f09cb39a.png">

> Only show the dataset and model, and also added the jobs by pipeline id.

For Job View:

<img width="1440" alt="Screen Shot 2020-06-19 at 7 44 45 PM" src="https://user-images.githubusercontent.com/1935767/85129250-5ecaa000-b265-11ea-9f61-0fb7af682966.png">


> Optimize the cell styles and add model download feature.