### PR TITLE
cli: optimize the pipcook-daemon error

### DIFF
--- a/packages/cli/src/bin/pipcook-daemon.ts
+++ b/packages/cli/src/bin/pipcook-daemon.ts
@@ -23,7 +23,7 @@ async function start(): Promise<void> {
 
   // check if the process is running...
   if (await pathExists(DAEMON_PIDFILE)) {
-    spinner.fail('daemon is running...');
+    spinner.fail('starting daemon but ${DAEMON_PIDFILE} exists.');
     return;
   }
   spinner.start('starting Pipcook...');

--- a/packages/daemon/bootstrap.js
+++ b/packages/daemon/bootstrap.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const http = require('http');
 const path = require('path');
 const os = require('os');
@@ -11,6 +10,12 @@ const PIPCOOK_HOME = os.homedir() + '/.pipcook';
 const DAEMON_PIDFILE = PIPCOOK_HOME + '/daemon.pid';
 const DAEMON_CONFIG = PIPCOOK_HOME + '/daemon.config.json';
 const PORT = 6927;
+
+const isChildMode = typeof process.send === 'function';
+const bootstrapProcessState = {
+  willExit: null,
+  exitCode: 0
+};
 
 function createPidfileSync(pathname) {
   if (fs.existsSync(DAEMON_PIDFILE)) {
@@ -30,6 +35,9 @@ function createPidfileSync(pathname) {
 }
 
 (async function bootstrap() {
+  // delegate the stdio to access log.
+  delegateStdio();
+
   // create pidfile firstly
   createPidfileSync(DAEMON_PIDFILE);
 
@@ -55,35 +63,60 @@ function createPidfileSync(pathname) {
     framework: midwayPathname,
     typescript: true
   };
-  const app = await start(opts);
 
-  const server = http.createServer(app.callback());
-  server.once('error', err => {
-    console.error('app server got error: %s, code: %s', err.message, err.code);
-    process.exit(1);
-  });
+  try {
+    const app = await start(opts);
+    const server = http.createServer(app.callback());
+    server.once('error', err => {
+      console.error('app server got error: %s, code: %s', err.message, err.code);
+      process.exit(1);
+    });
 
-  // emit `server` event in app
-  app.emit('server', server);
+    // emit `server` event in app
+    app.emit('server', server);
 
-  // server listen
-  await new Promise(resolve => {
-    server.listen(PORT, resolve);
-  });
+    // server listen
+    await new Promise(resolve => {
+      server.listen(PORT, resolve);
+    });
+  } catch (err) {
+    // fs.writeFileSync(PIPCOOK_HOME + '/daemon.access.log', err.stack);
+    console.error(err);
+    return exitProcess(1);
+  }
 
   process.title = 'pipcook.daemon';
   console.info('Server is listening at http://localhost:%s, cost %ss', PORT, process.uptime());
 
-  if (typeof process.send === 'function') {
-    prepareToReady();
-  }
+  prepareToReady();
 })();
 
+function exitProcess(code) {
+  bootstrapProcessState.willExit = true;
+  bootstrapProcessState.exitCode = code;
+}
+
+function delegateStdio() {
+  if (!isChildMode) {
+    return;
+  }
+   // FIXME(Yorkie): monkeypatch the process.stdout(stderr) to redirect logs to the access log file.
+  const access = fs.createWriteStream(PIPCOOK_HOME + '/daemon.access.log');
+  const writeLog = (msg) => {
+    access.write(msg, () => {
+      if (bootstrapProcessState.willExit === true) {
+        process.exit(bootstrapProcessState.exitCode);
+      }
+    });
+  };
+  process.stdout.write = writeLog;
+  process.stderr.write = writeLog;
+}
+
 function prepareToReady() {
-  // FIXME(Yorkie): monkeypatch the process.stdout(stderr) to redirect logs to the access log file.
-  const access = fs.createWriteStream(PIPCOOK_HOME + '/daemon.access.log')
-  process.stdout.write = access.write.bind(access);
-  process.stderr.write = access.write.bind(access);
+  if (!isChildMode) {
+    return;
+  }
   process.send({
     event: 'ready',
     data: {


### PR DESCRIPTION
This optimizes the logs when the daemon starts failed:

- checking if the daemon is running via pidfile.
- outputs the access log when it failed.
- handles the daemon `exit`.
