### PR TITLE
daemon: redirect to index.html for default router

### DIFF
--- a/packages/daemon/src/app/controller/index.ts
+++ b/packages/daemon/src/app/controller/index.ts
@@ -1,0 +1,13 @@
+import { Context, controller, inject, provide, get } from 'midway';
+
+@provide()
+@controller('/')
+export class IndexController {
+  @inject()
+  ctx: Context;
+
+  @get('/')
+  public async index() {
+    this.ctx.redirect('/index.html');
+  }
+}


### PR DESCRIPTION
The current index(/) route returns 404, this changes to redirect to `/index.html`.