### PR TITLE
plugin: remove unneeded boa dep

### DIFF
--- a/packages/plugins/model-train/image-generation-tensorflow-model-train/package.json
+++ b/packages/plugins/model-train/image-generation-tensorflow-model-train/package.json
@@ -13,7 +13,6 @@
   "author": "Feely <feely@outlook.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "@pipcook/boa": "^0.7.1",
     "@pipcook/pipcook-core": "^0.7.1"
   },
   "gitHead": "1e21ad0799e221dcf4b7aa3a3b2187d5b8d8b865",


### PR DESCRIPTION
The plugin "image-generation-tensorflow-model-train" doesn't use the `boa` package, just remove it.