### PR TITLE
boa: clean tmp files for pybind11 after make

### DIFF
--- a/packages/boa/package.json
+++ b/packages/boa/package.json
@@ -4,7 +4,7 @@
   "description": "Use Python modules seamlessly in Node.js",
   "main": "lib/index.js",
   "scripts": {
-    "clean": "sh tools/clean-python.sh; make -C ./pybind11/ clean",
+    "clean": "sh tools/clean-python.sh && make -C ./pybind11/ clean",
     "preinstall": "make -C ./pybind11/ && node tools/install-python.js && node tools/install-requirements.js",
     "postinstall": "npm run build",
     "test": "tap --no-cov ./tests/**/*.js",

--- a/packages/boa/package.json
+++ b/packages/boa/package.json
@@ -4,7 +4,7 @@
   "description": "Use Python modules seamlessly in Node.js",
   "main": "lib/index.js",
   "scripts": {
-    "clean": "sh tools/clean-python.sh",
+    "clean": "sh tools/clean-python.sh; make -C ./pybind11/ clean",
     "preinstall": "make -C ./pybind11/ && node tools/install-python.js && node tools/install-requirements.js",
     "postinstall": "npm run build",
     "test": "tap --no-cov ./tests/**/*.js",

--- a/packages/boa/pybind11/Makefile
+++ b/packages/boa/pybind11/Makefile
@@ -1,22 +1,34 @@
 ROOT=$(abspath .)
 VERSION=2.4.3
 
-BUILD=$(ROOT)/src/
-ARCHIVE_DIR=$(BUILD)pybind11-$(VERSION)
-TARBALL=$(ROOT)/downloads/pybind11-v$(VERSION).tgz
+BUILD=$(ROOT)/src
+DOWNLOAD_DIR=$(ROOT)/downloads
+ARCHIVE_DIR=$(DOWNLOAD_DIR)/pybind11-$(VERSION)
+TARBALL=$(DOWNLOAD_DIR)/pybind11-v$(VERSION).tgz
 URL=https://github.com/pybind/pybind11/archive/v$(VERSION).tar.gz
+
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-MD5CMD=md5sum --quiet --check checksums
+	MD5CMD=md5sum --quiet --check checksums
+	DOWNLOAD=wget -O $(TARBALL) $(URL)
+endif
+ifeq ($(UNAME_S), Darwin)
+	DOWNLOAD=curl -L -o $(TARBALL) $(URL)
 endif
 
-all: $(BUILD)
+all: pybind11
 
-$(BUILD): $(TARBALL)
-	[ -d $(BUILD) ] || (mkdir -p $(dir $(BUILD));\
-	tar -C $(dir $(BUILD)) -xf $(TARBALL); mv $(ARCHIVE_DIR)/* $(BUILD); rm -r $(ARCHIVE_DIR))
+pybind11: $(BUILD)
 
-$(TARBALL):
-	[ -d $(ROOT)/downloads ] || mkdir $(ROOT)/downloads
-	wget -O $@ $(URL)
+$(BUILD):
+	rm -rf $(BUILD)
+	mkdir -p $(ROOT)/downloads
+	[ -f $(TARBALL) ] || $(DOWNLOAD)
 	$(MD5CMD)
+	tar -C $(dir $(ARCHIVE_DIR)) -xf $(TARBALL)
+	mv $(ARCHIVE_DIR) $(BUILD)
+	rm -rf $(DOWNLOAD_DIR)
+
+clean:
+	rm -rf $(BUILD)
+	rm -rf $(DOWNLOAD_DIR)


### PR DESCRIPTION
After `npm install` for boa, there is a download directory left, should be removed.