### PR TITLE
cli: add new command `daemon debug` for debugging the daemon service

### DIFF
--- a/docs/manual/pipcook-tools.md
+++ b/docs/manual/pipcook-tools.md
@@ -159,5 +159,25 @@ To stop the currently running daemon:
 $ pipcook daemon stop
 ```
 
+Check out the daemon logs via:
+
+```sh
+$ cat `pipcook daemon logfile`
+```
+
+To monit the daemon process, run the following command:
+
+```sh
+$ pipcook daemon monit
+```
+
+To start the daemon process in foreground mode for debugging:
+
+```sh
+$ pipcook daemon debug
+```
+
+This will run the daemon service in the current process, and it would be shutdown after the Pipcook Tools session is end.
+
 [Pipcook Daemon]: ../GLOSSORY.md#pipcook-daemon
 [Pipboard]: ../GLOSSORY.md#pipboard

--- a/docs/zh-cn/manual/pipcook-tools.md
+++ b/docs/zh-cn/manual/pipcook-tools.md
@@ -159,5 +159,25 @@ $ pipcook daemon restart
 $ pipcook daemon stop
 ```
 
+查看服务历史日志：
+
+```sh
+$ cat `pipcook daemon logfile`
+```
+
+通过如下命令，查看服务的实时日志：
+
+```sh
+$ pipcook daemon monit
+```
+
+有时候为了调试服务，需要前台运行服务：
+
+```sh
+$ pipcook daemon debug
+```
+
+这种模式下，服务是运行在当前进程，当命令行工具的生命周期结束后，服务也会退出。
+
 [Pipcook Daemon]: ../GLOSSORY.md#pipcook-daemon
 [Pipboard]: ../GLOSSORY.md#pipboard

--- a/packages/cli/src/bin/pipcook-daemon.ts
+++ b/packages/cli/src/bin/pipcook-daemon.ts
@@ -23,7 +23,7 @@ async function start(): Promise<void> {
 
   // check if the process is running...
   if (await pathExists(DAEMON_PIDFILE)) {
-    spinner.fail('starting daemon but ${DAEMON_PIDFILE} exists.');
+    spinner.fail(`starting daemon but ${DAEMON_PIDFILE} exists.`);
     return;
   }
   spinner.start('starting Pipcook...');
@@ -70,8 +70,12 @@ function tail(file: string): void {
 }
 
 async function monitor(): Promise<void> {
-  tail(`${PIPCOOK_HOME}/daemon.stdout.log`);
-  tail(`${PIPCOOK_HOME}/daemon.stderr.log`);
+  tail(`${PIPCOOK_HOME}/daemon.access.log`);
+}
+
+async function debugDaemon(): Promise<void> {
+  await stop();
+  require(path.join(DAEMON_HOME, 'bootstrap.js'));
 }
 
 program
@@ -103,5 +107,11 @@ program
   .action(() => {
     console.info(PIPCOOK_HOME + '/daemon.access.log');
   });
+
+program
+  .command('debug')
+  .description('start the pipcook daemon in foreground for debugging.')
+  .option('--verbose', 'open the verbose/debug logs')
+  .action(debugDaemon);
 
 program.parse(process.argv);

--- a/packages/cli/src/bin/pipcook-daemon.ts
+++ b/packages/cli/src/bin/pipcook-daemon.ts
@@ -75,6 +75,7 @@ async function monitor(): Promise<void> {
 
 async function debugDaemon(): Promise<void> {
   await stop();
+  process.env.DEBUG = 'costa*';
   require(path.join(DAEMON_HOME, 'bootstrap.js'));
 }
 
@@ -111,7 +112,6 @@ program
 program
   .command('debug')
   .description('start the pipcook daemon in foreground for debugging.')
-  .option('--verbose', 'open the verbose/debug logs')
   .action(debugDaemon);
 
 program.parse(process.argv);


### PR DESCRIPTION
Typing the daemon directory path should be not that easy, this PR adds a new command `daemon debug`, which starts the service in current process, it simplifies debugging when sometimes we want users to start the daemon manually.