### PR TITLE
boa: fix import { X } from Y

### DIFF
--- a/packages/boa/src/core/object.cc
+++ b/packages/boa/src/core/object.cc
@@ -295,7 +295,7 @@ Napi::Value PythonObject::GetItem(const CallbackInfo &info) {
       std::string keystr = std::string(info[0].As<String>());
       if (PyModule_Check(_self.ptr())) {
         pybind::dict dict = pybind::reinterpret_borrow<pybind::dict>(
-          PyModule_GetDict(_self.ptr()));
+            PyModule_GetDict(_self.ptr()));
         if (dict.contains(keystr.c_str())) {
           pybind::object submodule = dict[keystr.c_str()];
           if (submodule && PyModule_Check(submodule.ptr()))

--- a/packages/boa/src/core/object.cc
+++ b/packages/boa/src/core/object.cc
@@ -294,7 +294,8 @@ Napi::Value PythonObject::GetItem(const CallbackInfo &info) {
       // otherwise, assert the key must be a string.
       std::string keystr = std::string(info[0].As<String>());
       if (PyModule_Check(_self.ptr())) {
-        pybind::dict dict = pybind::reinterpret_borrow<pybind::dict>(PyModule_GetDict(_self.ptr()));
+        pybind::dict dict = pybind::reinterpret_borrow<pybind::dict>(
+          PyModule_GetDict(_self.ptr()));
         if (dict.contains(keystr.c_str())) {
           pybind::object submodule = dict[keystr.c_str()];
           if (submodule && PyModule_Check(submodule.ptr()))


### PR DESCRIPTION
fix issue: https://github.com/alibaba/pipcook/issues/170
```js
const { Image } = boa.import('PIL'); // working
const Image = boa.import('PIL.Image'); // working
const PIL = boa.import('PIL'); // working
console.log(PIL.Image); //working
```
The difference between Python and BOA implementations is:
* python
The submodule `Image` is created when module `PIL` is creating.
* boa
The module `PIL` is created, then sub module `Image` is requested, finally the `Image` is created and put into `PIL`.
