### PR TITLE
cli: daemon-stop use SIGINT as the default signal.

### DIFF
--- a/packages/cli/src/bin/pipcook-daemon.ts
+++ b/packages/cli/src/bin/pipcook-daemon.ts
@@ -55,7 +55,6 @@ async function stop(): Promise<void> {
     const oldPid = parseInt(await readFile(DAEMON_PIDFILE, 'utf8'), 10);
     try {
       process.kill(oldPid, 'SIGINT');
-      // exec(`kill -SIGINT ${oldPid}`);
       spinner.succeed('Pipcook stoped.');
     } catch (err) {
       await remove(DAEMON_PIDFILE);

--- a/packages/cli/src/bin/pipcook-daemon.ts
+++ b/packages/cli/src/bin/pipcook-daemon.ts
@@ -54,7 +54,8 @@ async function stop(): Promise<void> {
   if (await pathExists(DAEMON_PIDFILE)) {
     const oldPid = parseInt(await readFile(DAEMON_PIDFILE, 'utf8'), 10);
     try {
-      exec(`kill ${oldPid}`);
+      process.kill(oldPid, 'SIGINT');
+      // exec(`kill -SIGINT ${oldPid}`);
       spinner.succeed('Pipcook stoped.');
     } catch (err) {
       await remove(DAEMON_PIDFILE);


### PR DESCRIPTION
The current by-default kill causes the costa process is still running after the daemon is killed by cli, thanks @lewis617 for catching this :p