### PR TITLE
plugin: fix the dependencies for fs-extra

### DIFF
--- a/packages/plugins/data-collect/csv-data-collect/package.json
+++ b/packages/plugins/data-collect/csv-data-collect/package.json
@@ -14,7 +14,7 @@
     "compile": "tsc -b tsconfig.json"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache 2.0",
   "dependencies": {
     "@pipcook/pipcook-core": "^1.0.1",
     "csv-parse": "^4.8.8",

--- a/packages/plugins/data-collect/csv-data-collect/package.json
+++ b/packages/plugins/data-collect/csv-data-collect/package.json
@@ -17,10 +17,9 @@
   "license": "ISC",
   "dependencies": {
     "@pipcook/pipcook-core": "^1.0.1",
-    "@types/fs-extra": "^8.1.0",
-    "@types/uuid": "^7.0.2",
     "csv-parse": "^4.8.8",
     "csv-stringify": "^5.3.6",
+    "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
     "glob-promise": "^3.4.0",
     "uuid": "^7.0.2"
@@ -28,6 +27,8 @@
   "gitHead": "53e131a069b3112a74ae5d99aa1ab08bec768c7e",
   "devDependencies": {
     "@types/jasmine": "^3.5.7",
+    "@types/fs-extra": "^8.1.0",
+    "@types/uuid": "^7.0.2",
     "nyc": "14.1.1"
   },
   "publishConfig": {


### PR DESCRIPTION
This fixes the problem:

```sh
2020-07-08 20:57:33,032 ERROR 30029 nodejs.TypeError: Cannot find module 'fs-extra'
Require stack:
- /Users/yorkie/.pipcook/plugins/node_modules/@pipcook/plugins-csv-data-collect/dist/index.js
- /Users/yorkie/workspace/pipcook/packages/costa/dist/client.js
Require stack:
- /Users/yorkie/.pipcook/plugins/node_modules/@pipcook/plugins-csv-data-collect/dist/index.js
- /Users/yorkie/workspace/pipcook/packages/costa/dist/client.js
    at PluginRunnable.<anonymous> (/Users/yorkie/workspace/pipcook/packages/costa/dist/runnable.js:139:23)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/yorkie/workspace/pipcook/packages/costa/dist/runnable.js:5:58)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```