### PR TITLE
daemon: dont print the boa not found stacktrace

### DIFF
--- a/packages/daemon/templates/boapkg.js
+++ b/packages/daemon/templates/boapkg.js
@@ -12,7 +12,6 @@ try {
   condaInstallDir = fs.readFileSync(`${boaSrcPath}/.CONDA_INSTALL_DIR`, 'utf8');
   fs.accessSync(condaInstallDir);
 } catch (err) {
-  console.error(err);
   console.warn('no @pipcook/boa installed, just skip');
   return process.exit(0);
 }


### PR DESCRIPTION
This makes someone think it's broken, actually run `node index.js` is ok.