### PR TITLE
costa: add bootstrap script for bootstrap

### DIFF
--- a/packages/costa/benchmark/bootstrap.js
+++ b/packages/costa/benchmark/bootstrap.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { join } = require('path');
+const { CostaRuntime } = require('../dist/runtime');
+const { PluginRunnable } = require('../dist/runnable');
+
+const costa = new CostaRuntime({
+  installDir: join(__dirname, '../.tests/plugins'),
+  datasetDir: join(__dirname, '../.tests/datasets'),
+  componentDir: join(__dirname, '../.tests/components'),
+  npmRegistryPrefix: 'https://registry.npmjs.com/'
+});
+const r = new PluginRunnable(costa);
+
+(async () => {
+  await r.bootstrap({});
+  r.destroy();
+})()

--- a/packages/costa/benchmark/bootstrap.js
+++ b/packages/costa/benchmark/bootstrap.js
@@ -15,4 +15,4 @@ const r = new PluginRunnable(costa);
 (async () => {
   await r.bootstrap({});
   r.destroy();
-})()
+})();

--- a/packages/costa/benchmark/makefile
+++ b/packages/costa/benchmark/makefile
@@ -1,0 +1,4 @@
+export DEBUG=costa*
+
+bootstrap:
+	time node ./bootstrap.js


### PR DESCRIPTION
To run the bootstrap benchmark for costa:

```sh
$ cd packages/costa
$ make -C benchmark
time node ./bootstrap.js
  costa.runnable make sure the component dir is existed. +0ms
  costa.runnable bootstrap a new process for c00b5cf0-c26f-11ea-93dc-2165bcacf22a. +4ms
  costa.runnable sent handshake for c00b5cf0-c26f-11ea-93dc-2165bcacf22a, and wait for response +9ms
  costa.runnable the runnable(c00b5cf0-c26f-11ea-93dc-2165bcacf22a) has been destroyed with(code=0, signal=null). +106ms
        0.44 real         0.40 user         0.08 sys
```