### PR TITLE
costa: use ~/.pipcook/plugins/.pip as the default cache dir

### DIFF
--- a/packages/costa/src/client.ts
+++ b/packages/costa/src/client.ts
@@ -124,7 +124,7 @@ async function emitStart(message: PluginMessage): Promise<void> {
       recv(PluginOperator.WRITE);
     }
   } catch (err) {
-    recv(PluginOperator.WRITE, 'error', err?.message);
+    recv(PluginOperator.WRITE, 'error', err?.stack);
   }
 }
 

--- a/packages/costa/src/runtime.ts
+++ b/packages/costa/src/runtime.ts
@@ -309,7 +309,10 @@ export class CostaRuntime {
         if (pyIndex) {
           args = args.concat([ '-i', pyIndex ]);
         }
-        args = args.concat([ '--default-timeout=1000' ]);
+        args = args.concat([
+          '--default-timeout=1000',
+          `--cache-dir=${this.options.installDir}/.pip`
+        ]);
         await spawnAsync(`${envDir}/bin/pip3`, args);
       }
     } else {

--- a/packages/plugins/model-train/bayesian-model-train/package.json
+++ b/packages/plugins/model-train/bayesian-model-train/package.json
@@ -14,7 +14,7 @@
     "compile": "tsc -b tsconfig.json && cp -r ./src/assets ./dist/"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache 2.0",
   "dependencies": {
     "@pipcook/boa": "^1.0.3",
     "@pipcook/pipcook-core": "^1.0.3",
@@ -39,7 +39,7 @@
     "python": "3.7",
     "dependencies": {
       "jieba": "*",
-      "sklearn": "*"
+      "scikit-learn": "*"
     }
   }
 }


### PR DESCRIPTION
This provides a specific path for pip's `--cache-dir`, it fixes not caching in PC where the pip's cache environment not getting set up.