### PR TITLE
build: fix the pipeline action

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -25,6 +25,8 @@ jobs:
     - name: initilize pipcook
       env:
         NODE_ENV: local
-      run: ./packages/cli/dist/bin/pipcook init
+      run: |
+        ./packages/cli/dist/bin/pipcook init
+        ./packages/cli/dist/bin/pipcook daemon start
     - name: pipeline
       run: npm run test:pipeline -- ${{ matrix.pipeline }}


### PR DESCRIPTION
Our current pipeline builds are failed, see https://github.com/alibaba/pipcook/runs/871744946?check_suite_focus=true. Just fix this by adding `pipcook daemon start`.