### PR TITLE
add .ps_project dir for gradientci

### DIFF
--- a/.ps_project/config.yaml
+++ b/.ps_project/config.yaml
@@ -1,6 +1,6 @@
 version: 2
 workflows:
-  run-pipcook-pipeline:
+  run-pipeline:
     steps:
       -
         name: "run image classification"
@@ -9,6 +9,6 @@ workflows:
           command: nvidia-smi
           container: pipcook/pipcook:latest
           machineType: "K80"
-      triggers:
-        branches:
-          only: integrate/gpu-ci
+    triggers:
+      branches:
+        only: integrate/gpu-ci

--- a/.ps_project/config.yaml
+++ b/.ps_project/config.yaml
@@ -1,0 +1,14 @@
+version: 2
+workflows:
+  run-pipcook-pipeline:
+    steps:
+      -
+        name: "run image classification"
+        command: experiment.run_single_node
+        params:
+          command: nvidia-smi
+          container: pipcook/pipcook:latest
+          machineType: "K80"
+      triggers:
+        branches:
+          only: integrate/gpu-ci


### PR DESCRIPTION
Paperspace provides free [GPU-enabled CI](https://docs.paperspace.com/gradient/projects/gradientci-v2/gradientci-v2#steps) for GitHub open source project, this PR is to integrate some of our pipelines on GradientCI.