### PR TITLE
boa: remove no-process-env disable annotation

### DIFF
--- a/packages/boa/lib/index.js
+++ b/packages/boa/lib/index.js
@@ -13,9 +13,7 @@ const IterIdxForSeqSymbol = Symbol('The iteration index for sequence');
 // read the conda path from the .CONDA_INSTALL_DIR
 // eslint-disable-next-line no-sync
 const condaPath = fs.readFileSync(path.join(__dirname, '../.CONDA_INSTALL_DIR'), 'utf8');
-// eslint-disable-next-line no-process-env
 if (!process.env.PYTHONHOME) {
-  // eslint-disable-next-line no-process-env
   process.env.PYTHONHOME = condaPath;
 }
 


### PR DESCRIPTION
Remove annotation for `no-process-env`, because the rule has been disabled.