### PR TITLE
fix predict script

### DIFF
--- a/packages/daemon/templates/node/predict.js
+++ b/packages/daemon/templates/node/predict.js
@@ -18,24 +18,22 @@ if (typeof pipeline.dataProcess === 'string') {
 }
 
 const dataset = JSON.parse(output.dataset);
-const model = modelDefineModule(null, {
+const modelDefine = modelDefineModule(null, {
   recoverPath: __dirname + '/model',
   dataset
 });
 
-function predict(data) {
-  const sample = { data, label: null };
-  let future = model;
+let model;
 
-  if (typeof dataProcessModule === 'function') {
-    future = future.then((m) => {
-      dataProcessModule(sample, {}, JSON.parse(pipeline.dataProcessParams));
-      return m
-    });
+async function predict(data) {
+  if (!model) {
+    model = await modelDefine;
   }
-  return future.then((m) => {
-    return m.predict(sample);
-  });
+  const sample = { data, label: null };
+  if (typeof dataProcessModule === 'function') {
+    await dataProcessModule(sample, {}, JSON.parse(pipeline.dataProcessParams));
+  }
+  return await model.predict(sample);
 };
 
 module.exports = predict;


### PR DESCRIPTION
Currently, the script 'preidct.js' is generated to output folder when the pipeline is finished. However, in predcit.js, data process method's promise is not resolved before the model starts to predict, which causes problems. This PR is to fix this.

This problem causes error when we predict tfjs image classification:

```
ValueError: Error when checking : expected conv2d_Conv2D1_input to have shape [null,28,28,3] but got array with shape [1,1440,1080,3].
```