### PR TITLE
boa: use the specific version to fix build failure

### DIFF
--- a/packages/boa/tools/install-python.js
+++ b/packages/boa/tools/install-python.js
@@ -13,7 +13,7 @@ if (process.env.BOA_CONDA_MIRROR) {
 }
 
 const CONDA_LOCAL_PATH = initAndGetCondaPath();
-let condaDownloadName = 'Miniconda3-latest';
+let condaDownloadName = 'Miniconda3-4.7.12.1';
 
 if (PLATFORM === 'linux') {
   condaDownloadName += '-Linux';


### PR DESCRIPTION
The latest miniconda has switched to Python 3.8 :)