### PR TITLE
notebook: remove `sudo` in the code cell

### DIFF
--- a/notebooks/pipcook_image_classification.ipynb
+++ b/notebooks/pipcook_image_classification.ipynb
@@ -97,8 +97,8 @@
         "colab": {}
       },
       "source": [
-        "!sudo pipcook init\n",
-        "!sudo pipcook daemon start"
+        "!pipcook init\n",
+        "!pipcook daemon start"
       ],
       "execution_count": null,
       "outputs": []

--- a/notebooks/pipcook_object_detection.ipynb
+++ b/notebooks/pipcook_object_detection.ipynb
@@ -96,8 +96,8 @@
         "colab": {}
       },
       "source": [
-        "!sudo pipcook init\n",
-        "!sudo pipcook daemon start"
+        "!pipcook init\n",
+        "!pipcook daemon start"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
When running `!sudo pipcook init` and `!sudo pipcook daemon start` in my Notebook, this error ocurred:

```bash
/bin/sh: 1: sudo: not found
/bin/sh: 1: sudo: not found
```

And I was previously told to run `pipcook init` without `sudo`. [https://github.com/alibaba/pipcook/issues/314](https://github.com/alibaba/pipcook/issues/314)