### PR TITLE
costa: add python runnable for machine-learning developers

### DIFF
--- a/docs/contributing/contribute-a-plugin.md
+++ b/docs/contributing/contribute-a-plugin.md
@@ -25,27 +25,7 @@ const collectTextline: DataCollectType = async (args: ArgsType): Promise<void> =
 For other plugin interfaces, see [this list of plugin categories](../spec/plugin.md#plugin-category).
 
 
-## Test your plugin
-
-You can prepare the corresponding mocking data based on the interface. For example, if you developed a `DataProcessType` plugin, create some mock firstly:
-
-```js
-const data = {
-  trainData: tf.data.array([{xs: [1,2,3], ys: [1]},{xs: [4,5,6], ys: [2]}]),
-  metaData: {
-    feature: {
-      name: 'train',
-      type: 'int32',
-      shape: [1,3]
-    },
-    label: {
-      name: 'test,
-      type: 'int32',
-      shape: [1]
-    },
-  }
-};
-```
+## Plugin development
 
 If the `DataProcessType` plugin needs to double the size of each feature, you can implement your plugin as follows:
 
@@ -63,6 +43,42 @@ You need to check the following two before releasing that:
 - the returned value of your plugin comply with the [plugin specfication](../spec/plugin.md).
 
 After ensuring the preceding the above, you can run a real pipeline to check whether your plugin is compatible with the corresponding upstream and downstream plugins.
+
+### Developing with Python
+
+In order to allow some non-Node.js developers (such as algorithm engineers) to contribute plugins to Pipcook, we provide a plugin development environment based entirely on Python. The script is as follows:
+
+```py
+# __init__.py
+def main(sample, metadata, args):
+  sample.data *= 2
+```
+
+Pipcook agrees that the `main` function is used as the entrance of the plugin. The parameters are consistent with those of the Node.js plugin. The file also needs to be named `__init__.py`. In addition, you need to add in package.json:
+
+```json
+{
+  "pipcook": {
+    "runtime": "python"
+  }
+}
+```
+
+In this way, when Pipcook loads the plugin, it will use the Python loader to load. If you need to use a third-party library of Python, you can also declare under `conda.dependencies` as follows:
+
+```json
+{
+  "pipcook": {
+    "runtime": "python"
+  },
+  "conda": {
+    "dependencies": {
+      "tensorflow": "*",
+      "numpy": "*"
+    }
+  }
+}
+```
 
 ## Release
 

--- a/docs/zh-cn/contributing/contribute-a-plugin.md
+++ b/docs/zh-cn/contributing/contribute-a-plugin.md
@@ -61,6 +61,7 @@ Pipcook 约定 `main` 函数作为了插件的入口，参数与 Node.js 插件�
     "runtime": "python"
   }
 }
+```
 
 这样，当 Pipcook 在加载插件时，就会使用 Python 加载器来加载插件了，如需使用 Python 的第三方库，同样在 `conda.dependencies` 下申明即可如：
 

--- a/docs/zh-cn/spec/plugin.md
+++ b/docs/zh-cn/spec/plugin.md
@@ -18,7 +18,8 @@
   },
   "pipcook": {
     "category": "dataCollect",
-    "datatype": "image"
+    "datatype": "image",
+    "runtime": "nodejs"
   },
   "conda": {
     "python": "3.7",
@@ -36,6 +37,7 @@
 - 需要添加一个根节点 `pipcook`，
   - `pipcook.category` 用于描述插件类型，所有的类型可以看[这里](#分类)。
   - `pipcook.datatype` 用于描述插件所处理的数据类型，目前支持：`common`、`image` 和 `text`。
+  - `pipcook.runtime` 用于描述插件运行时的类型，目前支持 `nodejs` 和 `python`。
 - 可选的节点 `conda`，用于配置 Python 相关的依赖，
   - `conda.python` 用于声明 Python 版本，目前必须是 3.7。
   - `conda.dependencies` 用于声明插件会使用到的 Python 包，Pipcook 会在初始化插件时进行安装，它支持以下的版本声明方式：

--- a/packages/costa/package.json
+++ b/packages/costa/package.json
@@ -2,14 +2,14 @@
   "name": "@pipcook/costa",
   "version": "1.0.4",
   "description": "The Pipcook Plugin Runtime",
-  "main": "dist/runtime",
-  "types": "dist/runtime",
+  "main": "dist/src/runtime",
+  "types": "dist/src/runtime",
   "files": [
     "dist"
   ],
   "scripts": {
     "pretest": "rm -rf .tests",
-    "test": "ts-node ../../run_tests.ts --spec 'dist/*_test.js'",
+    "test": "ts-node ../../run_tests.ts --spec 'dist/test/runnable_test.js'",
     "build": "npm run clean && npm run compile",
     "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
     "compile": "tsc -b tsconfig.json"

--- a/packages/costa/src/client/entry.ts
+++ b/packages/costa/src/client/entry.ts
@@ -1,9 +1,11 @@
 import * as path from 'path';
 import { generate } from 'shortid';
-import { PluginProtocol, PluginOperator, PluginMessage } from './protocol';
-import { PluginPackage } from './index';
-import Debug from 'debug';
 import { UniDataset, DataLoader } from '@pipcook/pipcook-core';
+import Debug from 'debug';
+
+import { PluginProtocol, PluginOperator, PluginMessage } from '../protocol';
+import { PluginPackage } from '../index';
+import loadPlugin from './loaders';
 
 type MessageHandler = Record<PluginOperator, (proto: PluginProtocol) => void>;
 const debug = Debug('costa.client');
@@ -88,13 +90,7 @@ async function emitStart(message: PluginMessage): Promise<void> {
       }
     }
 
-    // get the plugin function.
-    let fn = require(pkg.name);
-    if (fn && typeof fn !== 'function' && typeof fn.default === 'function') {
-      // compatible with ESM default export.
-      fn = fn.default;
-    }
-
+    const fn = loadPlugin(pkg);
     if (pkg.pipcook.category === 'dataProcess') {
       // in "dataProcess" plugin, we need to do process them in one by one.
       const [ dataset, args ] = pluginArgs.map(deserializeArg) as [ UniDataset, any ];

--- a/packages/costa/src/client/loaders/index.ts
+++ b/packages/costa/src/client/loaders/index.ts
@@ -1,0 +1,13 @@
+import { PluginPackage } from '../../index';
+
+// import all loaders
+import loadAsNodeJs from './nodejs';
+import loadAsPython from './python';
+
+export default function(pkg: PluginPackage): Function {
+  const { runtime } = pkg.pipcook;
+  if (runtime === 'python') {
+    return loadAsPython(pkg);
+  }
+  return loadAsNodeJs(pkg);
+}

--- a/packages/costa/src/client/loaders/nodejs.ts
+++ b/packages/costa/src/client/loaders/nodejs.ts
@@ -1,0 +1,11 @@
+import { PluginPackage } from '../../index';
+
+export default function (pkg: PluginPackage): Function {
+  // get the plugin function.
+  let fn = require(pkg.name);
+  if (fn && typeof fn !== 'function' && typeof fn.default === 'function') {
+    // compatible with ESM default export.
+    fn = fn.default;
+  }
+  return fn;
+}

--- a/packages/costa/src/client/loaders/python.ts
+++ b/packages/costa/src/client/loaders/python.ts
@@ -1,0 +1,7 @@
+import { PluginPackage } from '../../index';
+const boa = require('@pipcook/boa');
+
+export default function (pkg: PluginPackage): Function {
+  const fn = boa.import(pkg.name);
+  return fn as Function;
+}

--- a/packages/costa/src/client/loaders/python.ts
+++ b/packages/costa/src/client/loaders/python.ts
@@ -1,7 +1,16 @@
 import { PluginPackage } from '../../index';
 const boa = require('@pipcook/boa');
+const sys = boa.import('sys');
 
 export default function (pkg: PluginPackage): Function {
-  const fn = boa.import(pkg.name);
-  return fn as Function;
+  const fn = boa.import(`node_modules.${pkg.name}`);
+  return (...args: any[]) => {
+    const res = fn.main(...args);
+
+    // flush all outputs(stdout/stderr).
+    const { stdout, stderr } = sys;
+    stdout.flush();
+    stderr.flush();
+    return res;
+  }
 }

--- a/packages/costa/src/client/loaders/python.ts
+++ b/packages/costa/src/client/loaders/python.ts
@@ -12,5 +12,5 @@ export default function (pkg: PluginPackage): Function {
     stdout.flush();
     stderr.flush();
     return res;
-  }
+  };
 }

--- a/packages/costa/src/index.ts
+++ b/packages/costa/src/index.ts
@@ -101,6 +101,10 @@ export interface PluginPackage {
       PYTHONPATH: string;
       DESTPATH: string;
     };
+    /**
+     * The plugin runtime
+     */
+    runtime?: 'nodejs' | 'python';
   };
   /**
    * The below is some information related to Python.

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -36,7 +36,6 @@ export interface BootstrapArg {
  * The runnable is to represent a container to run plugins.
  */
 export class PluginRunnable {
-  private id: string;
   private rt: CostaRuntime;
   private handle: ChildProcess = null;
 
@@ -48,6 +47,11 @@ export class PluginRunnable {
   private onread: Function | null;
   private onreadfail: Function | null;
   private ondestroyed: Function | null;
+
+  /**
+   * The runnable id.
+   */
+  public id: string;
 
   /**
    * the current working directory for this runnable.

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -87,7 +87,7 @@ export class PluginRunnable {
     this.stderr = await open(compPath + '/logs/stderr.log', 'w+');
 
     debug(`bootstrap a new process for ${this.id}.`);
-    this.handle = fork(__dirname + '/client', [], {
+    this.handle = fork(__dirname + '/client/entry', [], {
       stdio: [
         process.stdin, // stdin
         this.stdout,

--- a/packages/costa/src/runtime.ts
+++ b/packages/costa/src/runtime.ts
@@ -315,10 +315,12 @@ export class CostaRuntime {
 
     let boaSrcPath = path.join(__dirname, '../node_modules/@pipcook/boa');
     if (!await pathExists(boaSrcPath)) {
-      boaSrcPath = path.join(__dirname, '../../boa');
-    }
-    if (!await pathExists(boaSrcPath)) {
-      throw new TypeError('costa is not installed correctly, please try init again');
+      try {
+        // FIXME: ../../ means boa/lib/index.js
+        boaSrcPath = path.join(require.resolve('@pipcook/boa'), '../../');
+      } catch (err) {
+        throw new TypeError(`boa(${boaSrcPath}) not exists, please try init again.`);
+      }
     }
 
     const pluginStdName = `${pkg.name}@${pkg.version}`;

--- a/packages/costa/test/lrucache_test.ts
+++ b/packages/costa/test/lrucache_test.ts
@@ -1,4 +1,4 @@
-import LRUCache from './lrucache';
+import LRUCache from '../src/lrucache';
 
 describe('test lru cache', () => {
   it('should create a string lrucache.', () => {

--- a/packages/costa/test/plugins/nodejs-simple/index.js
+++ b/packages/costa/test/plugins/nodejs-simple/index.js
@@ -1,0 +1,4 @@
+
+module.exports = function(data) {
+  console.log(data);
+};

--- a/packages/costa/test/plugins/nodejs-simple/index.js
+++ b/packages/costa/test/plugins/nodejs-simple/index.js
@@ -1,4 +1,5 @@
 
 module.exports = function(data) {
   console.log(data);
+  return data.foobar;
 };

--- a/packages/costa/test/plugins/nodejs-simple/index.js
+++ b/packages/costa/test/plugins/nodejs-simple/index.js
@@ -1,5 +1,11 @@
 
 module.exports = function(data) {
   console.log(data);
-  return data.foobar;
+  return {
+    foobar: data.foobar,
+    fn1: (a) => console.log(`fn1(${a})`),
+    obj: {
+      fn2: () => console.log(`fn2()`),
+    },
+  };
 };

--- a/packages/costa/test/plugins/nodejs-simple/package.json
+++ b/packages/costa/test/plugins/nodejs-simple/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nodejs-simple",
+  "version": "1.0.0",
+  "description": "test nodejs simple",
+  "main": "index.js",
+  "dependencies": {
+    "@pipcook/pipcook-core": "^1.0.4"
+  },
+  "pipcook": {
+    "category": "modelDefine",
+    "datatype": "text"
+  }
+}

--- a/packages/costa/test/plugins/python-simple/__init__.py
+++ b/packages/costa/test/plugins/python-simple/__init__.py
@@ -1,0 +1,2 @@
+def main(args):
+  print("hello python!")

--- a/packages/costa/test/plugins/python-simple/__init__.py
+++ b/packages/costa/test/plugins/python-simple/__init__.py
@@ -2,7 +2,7 @@ import numpy as np
 
 def main(input):
   print('hello python!', input)
-  if 'fn1' in input:
+  if input.fn1:
     input.fn1(np.zeros(2))
     input.obj.fn2()
 

--- a/packages/costa/test/plugins/python-simple/__init__.py
+++ b/packages/costa/test/plugins/python-simple/__init__.py
@@ -2,7 +2,7 @@ import numpy as np
 
 def main(input):
   print('hello python!', input)
-  if input.fn1:
+  if hasattr(input, 'fn1'):
     input.fn1(np.zeros(2))
     input.obj.fn2()
 

--- a/packages/costa/test/plugins/python-simple/__init__.py
+++ b/packages/costa/test/plugins/python-simple/__init__.py
@@ -1,5 +1,10 @@
 import numpy as np
 
-def main(args):
-  print("hello python!", args)
+def main(input):
+  print('hello python!', input)
+  if 'fn1' in input:
+    # TODO(yorkie): support setattr
+    input.get('fn1')(np.zeros(2))
+    input.get('obj').get('fn2')()
+
   return np.zeros(10)

--- a/packages/costa/test/plugins/python-simple/__init__.py
+++ b/packages/costa/test/plugins/python-simple/__init__.py
@@ -3,8 +3,7 @@ import numpy as np
 def main(input):
   print('hello python!', input)
   if 'fn1' in input:
-    # TODO(yorkie): support setattr
-    input.get('fn1')(np.zeros(2))
-    input.get('obj').get('fn2')()
+    input.fn1(np.zeros(2))
+    input.obj.fn2()
 
   return np.zeros(10)

--- a/packages/costa/test/plugins/python-simple/__init__.py
+++ b/packages/costa/test/plugins/python-simple/__init__.py
@@ -1,2 +1,5 @@
+import numpy as np
+
 def main(args):
-  print("hello python!")
+  print("hello python!", args)
+  return np.zeros(10)

--- a/packages/costa/test/plugins/python-simple/package.json
+++ b/packages/costa/test/plugins/python-simple/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "python-simple",
+  "version": "1.0.0",
+  "description": "test python simple",
+  "main": "main.py",
+  "dependencies": {
+    "@pipcook/boa": "^1.0.4"
+  },
+  "pipcook": {
+    "category": "modelDefine",
+    "datatype": "text",
+    "runtime": "python"
+  },
+  "conda": {
+    "python": "3.7",
+    "dependencies": {
+      "numpy": "*"
+    }
+  }
+}

--- a/packages/costa/test/plugins/python-simple/package.json
+++ b/packages/costa/test/plugins/python-simple/package.json
@@ -2,7 +2,7 @@
   "name": "python-simple",
   "version": "1.0.0",
   "description": "test python simple",
-  "main": "main.py",
+  "main": "__init__.py",
   "dependencies": {
     "@pipcook/boa": "^1.0.4"
   },

--- a/packages/costa/test/protocol_test.ts
+++ b/packages/costa/test/protocol_test.ts
@@ -1,4 +1,4 @@
-import { PluginOperator, PluginProtocol } from './protocol';
+import { PluginOperator, PluginProtocol } from '../src/protocol';
 
 describe('test the plugin operator classes', () => {
   it('should read the correct number from PluginOperator', () => {

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -26,10 +26,11 @@ describe('start runnable in normal way', () => {
     expect(runnable.state).toBe('idle');
   });
 
+  let tmp: any;
   it('should start a nodejs plugin', async () => {
     const simple = await costa.fetch('./plugins/nodejs-simple', path.join(__dirname, '../../test'));
     await costa.install(simple, process);
-    const p = await runnable.start(simple, { foobar: true });
+    tmp = await runnable.start(simple, { foobar: true });
     const stdout = await readFile(path.join(opts.componentDir, runnable.id, 'logs/stdout.log'), 'utf8');
     expect(stdout.search('{ foobar: true }') !== 0).toBe(true);
   }, INSTALL_SPECS_TIMEOUT);
@@ -38,9 +39,16 @@ describe('start runnable in normal way', () => {
     const simple = await costa.fetch('./plugins/python-simple', path.join(__dirname, '../../test'));
     await costa.install(simple, process);
     expect(simple.pipcook.runtime).toBe('python');
-    const p = await runnable.start(simple, { foobar: true });
+
+    // test passing the variable from js to python.
+    const tmp2 = await runnable.start(simple, tmp);
     const stdout = await readFile(path.join(opts.componentDir, runnable.id, 'logs/stdout.log'), 'utf8');
     expect(stdout.search('hello python!') !== 0).toBe(true);
+
+    // test passing the variable from python to python.
+    await runnable.start(simple, tmp2);
+    const stdout2 = await readFile(path.join(opts.componentDir, runnable.id, 'logs/stdout.log'), 'utf8');
+    expect(stdout2.search('hello python! [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]') !== 0).toBe(true);
   }, INSTALL_SPECS_TIMEOUT);
 
   it('should destroy the runnable', async () => {

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -44,6 +44,8 @@ describe('start runnable in normal way', () => {
     const tmp2 = await runnable.start(simple, tmp);
     const stdout = await readFile(path.join(opts.componentDir, runnable.id, 'logs/stdout.log'), 'utf8');
     expect(stdout.search('hello python!') !== 0).toBe(true);
+    expect(stdout.search('fn1([0. 0.])') !== 0).toBe(true);
+    expect(stdout.search('fn2()') !== 0).toBe(true);
 
     // test passing the variable from python to python.
     await runnable.start(simple, tmp2);

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { CostaRuntime } from './runtime';
-import { PluginRunnable } from './runnable';
+import { CostaRuntime } from '../src/runtime';
+import { PluginRunnable } from '../src/runnable';
 import { readdir } from 'fs-extra';
 
 describe('start runnable in normal way', () => {

--- a/packages/costa/test/runtime_test.ts
+++ b/packages/costa/test/runtime_test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { CostaRuntime } from '../src/runtime';
-import { PluginPackage } from '..';
+import { PluginPackage } from '../src';
 import { stat } from 'fs-extra';
 import { spawnSync } from 'child_process';
 import { createReadStream } from 'fs-extra';

--- a/packages/costa/test/runtime_test.ts
+++ b/packages/costa/test/runtime_test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { CostaRuntime } from './runtime';
-import { PluginPackage } from '.';
+import { CostaRuntime } from '../src/runtime';
+import { PluginPackage } from '..';
 import { stat } from 'fs-extra';
 import { spawnSync } from 'child_process';
 import { createReadStream } from 'fs-extra';

--- a/packages/costa/tsconfig.json
+++ b/packages/costa/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
In order to better attract machine learning developers to contribute models to Pipcook, this PR provides developers with a native Python development environment. For users who do not use Node.js and JavaScript, they can use pure Python to write plugins.