### PR TITLE
boa: generate object instead of `dict` to Python function

### DIFF
--- a/packages/boa/lib/index.js
+++ b/packages/boa/lib/index.js
@@ -196,7 +196,9 @@ function _internalWrap(T, src={}) {
     invoke: {
       enumerable: false,
       writable: false,
-      value: args => T.invoke.apply(T, args),
+      value: args => {
+        return T.invoke.apply(T, args);
+      },
     },
     /**
      * @method toString

--- a/packages/boa/src/core/object.cc
+++ b/packages/boa/src/core/object.cc
@@ -422,7 +422,6 @@ PyObject *PythonObject::Cast(Napi::Env env, Object value,
                              bool finalizeFuncType) {
   auto names = value.GetPropertyNames();
   auto dict = PyDict_New();
-  auto isKwargs = IsKwargs(value);
 
   for (uint32_t i = 0; i < names.Length(); i++) {
     std::string nameStr = names.Get(i).As<String>();
@@ -435,7 +434,7 @@ PyObject *PythonObject::Cast(Napi::Env env, Object value,
     PyDict_SetItemString(dict, nameStr.c_str(), val);
   }
 
-  if (isKwargs) {
+  if (IsKwargs(value)) {
     // FIXME(yorkie): just return a dict object if it's for kwargs.
     return dict;
   }

--- a/packages/boa/tests/base/basic.js
+++ b/packages/boa/tests/base/basic.js
@@ -51,6 +51,16 @@ test('define a extended class with basic functions', t => {
   t.equal(f.test, 'pythonworld');
   t.equal(f.ping('yorkie'), 'hello <yorkie> on pythonworld');
   t.equal(f.callfunc(x => x * 2), 233 * 2);
+
+  const v = f.testObjPass({
+    input: 10,
+    fn1: x => x * 2,
+    scope: {
+      fn2: y => y * y,
+    },
+  });
+  // fn2(fn1(input))
+  t.equal(v, 400);
   t.end();
 });
 

--- a/packages/boa/tests/base/basic/__init__.py
+++ b/packages/boa/tests/base/basic/__init__.py
@@ -14,6 +14,10 @@ class Foobar(object):
   def callfunc(self, fn):
     return fn(233)
 
+  def testObjPass(self, obj):
+    v = obj.fn1(obj.input)
+    return obj.scope.fn2(v)
+
   def __enter__(self):
     self.entered = True
 

--- a/packages/boa/tests/stdlib/builtins.js
+++ b/packages/boa/tests/stdlib/builtins.js
@@ -73,14 +73,14 @@ test('`builtins.list` class', t => {
 });
 
 test('`builtins.len()` function', t => {
-  const { len } = builtins;
-  const dict = {
+  const { len, dict } = builtins;
+  const obj = {
     a0: 1,
     a1: 2,
     a2: 3,
   };
   const arr = [30, 31, 32, 100];
-  t.equal(len(dict), Object.keys(dict).length);
+  t.equal(len(dict(boa.kwargs(obj))), Object.keys(obj).length);
   t.equal(len(arr), arr.length);
   t.end();
 });

--- a/packages/plugins/model-define/tensorflow-cycle-gan-model-define/src/index.ts
+++ b/packages/plugins/model-define/tensorflow-cycle-gan-model-define/src/index.ts
@@ -2,7 +2,7 @@ import { ModelDefineType, UniModel, ModelDefineArgsType, Sample, ImageDataset } 
 import * as path from 'path';
 
 const boa = require('@pipcook/boa');
-const { tuple } = boa.builtins();
+const { tuple, dict } = boa.builtins();
 const sys = boa.import('sys');
 // TODO(Feely): support dot in the module name
 sys.path.insert(0, path.join(__dirname, '..'));
@@ -58,10 +58,10 @@ let opt = {
 };
 
 const cycleGanModelDefine: ModelDefineType = async (data: ImageDataset, args: ModelDefineArgsType): Promise<UniModel> => {
-  opt = {
+  opt = dict({
     ...opt,
     ...args
-  };
+  });
   const model = new CycleGAN(opt);
   const pipcookModel: UniModel = {
     model,

--- a/packages/plugins/model-train/image-generation-tensorflow-model-train/package.json
+++ b/packages/plugins/model-train/image-generation-tensorflow-model-train/package.json
@@ -13,6 +13,7 @@
   "author": "Feely <feely@outlook.com>",
   "license": "Apache 2.0",
   "dependencies": {
+    "@pipcook/boa": "^1.0.5",
     "@pipcook/pipcook-core": "^1.0.5"
   },
   "gitHead": "1e21ad0799e221dcf4b7aa3a3b2187d5b8d8b865",

--- a/packages/plugins/model-train/image-generation-tensorflow-model-train/src/index.ts
+++ b/packages/plugins/model-train/image-generation-tensorflow-model-train/src/index.ts
@@ -1,10 +1,10 @@
 import { ModelTrainType, UniModel, ImageDataset, ModelTrainArgsType } from '@pipcook/pipcook-core';
-import { boa } from '@pipcook/boa';
+const { dict } = require('@pipcook/boa').builtins();
 
 /**
  * training parameters
  */
-let trainOpt = {
+const trainOpt = {
   verbose: false,
   // save dir
   pic_dir: 'model',
@@ -21,7 +21,7 @@ let trainOpt = {
 };
 
 const cycleGANModelTrain: ModelTrainType = async (data: ImageDataset, model: UniModel, args: ModelTrainArgsType): Promise<UniModel> => {
-  const opt = boa.dict({
+  const opt = dict({
     ...trainOpt,
     ...args
   });

--- a/packages/plugins/model-train/image-generation-tensorflow-model-train/src/index.ts
+++ b/packages/plugins/model-train/image-generation-tensorflow-model-train/src/index.ts
@@ -1,4 +1,5 @@
 import { ModelTrainType, UniModel, ImageDataset, ModelTrainArgsType } from '@pipcook/pipcook-core';
+import { boa } from '@pipcook/boa';
 
 /**
  * training parameters
@@ -20,10 +21,10 @@ let trainOpt = {
 };
 
 const cycleGANModelTrain: ModelTrainType = async (data: ImageDataset, model: UniModel, args: ModelTrainArgsType): Promise<UniModel> => {
-  const opt = {
+  const opt = boa.dict({
     ...trainOpt,
     ...args
-  };
+  });
   const { trainLoader } = data;
   const aList = [];
   const bList = [];


### PR DESCRIPTION
It creates a new class and instantiates it with given props when passing to Python. For example:

```js
pythonfunc({ foobar: 10 });
```

At Python, we have to write in this way:

```py
def func(opt):
  opt.get('foobar') # 10, because opt is a dict
```

Within this Pull Request, the developer is able:

```py
def func(opt):
  opt.foobar
```

Otherwise, I also removed an incorrect case:

```js
const o = { foobar: 10 };
len(o); // not working
len(dict(boa.kwargs(o))); // working
```

Even though it's more complexed than before, but it's more correct way to be used.
