### PR TITLE
build: tweak the versions to decrease root packages' size

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -19,6 +19,12 @@
     },
     "bootstrap": {
       "nohoist": [
+        "@alifd/next",
+        "@icedesign/container",
+        "@icedesign/img",
+        "@icedesign/layout",
+        "@icedesign/notification",
+        "@icedesign/theme",
         "node-addon-api",
         "midway",
         "egg-ci",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1641,7 +1641,8 @@
     "@types/jasmine": {
       "version": "3.5.10",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.10.tgz",
-      "integrity": "sha512-3F8qpwBAiVc5+HPJeXJpbrl+XjawGmciN5LgiO7Gv1pl1RHtjoMNqZpqEksaPJW05ViKe8snYInRs6xB25Xdew=="
+      "integrity": "sha512-3F8qpwBAiVc5+HPJeXJpbrl+XjawGmciN5LgiO7Gv1pl1RHtjoMNqZpqEksaPJW05ViKe8snYInRs6xB25Xdew==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.4",
@@ -2010,19 +2011,11 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
-    "backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-      "dev": true,
-      "requires": {
-        "underscore": ">=1.8.3"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -2170,6 +2163,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2600,7 +2594,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -4300,7 +4295,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.12",
@@ -5251,6 +5247,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5716,6 +5713,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5724,7 +5722,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -5757,9 +5756,9 @@
       }
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "ip": {
@@ -6080,6 +6079,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
       "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.4",
         "jasmine-core": "~3.5.0"
@@ -6088,7 +6088,8 @@
     "jasmine-core": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
-      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA=="
+      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
+      "dev": true
     },
     "jasmine-spec-reporter": {
       "version": "5.0.2",
@@ -6098,12 +6099,6 @@
       "requires": {
         "colors": "1.4.0"
       }
-    },
-    "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6569,6 +6564,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -7078,6 +7074,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -7365,7 +7362,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -8202,9 +8200,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -8992,48 +8990,44 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.8.tgz",
-      "integrity": "sha512-a0zypcvfIFsS7Gqpf2MkC1+jNND3K1Om38pbDdy/gYWX01NuJZhC5+O0HkIp0oRIZOo7PWrA5+fC24zkANY28Q==",
+      "version": "0.17.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+      "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.3",
         "fs-extra": "^8.1.0",
-        "handlebars": "^4.7.0",
-        "highlight.js": "^9.17.1",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.0.0",
         "lodash": "^4.17.15",
-        "marked": "^0.8.0",
+        "lunr": "^2.3.8",
+        "marked": "1.0.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.6.3",
-        "typescript": "3.7.x"
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.10.2"
       },
       "dependencies": {
-        "marked": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+        "highlight.js": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
+          "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
           "dev": true
         },
-        "typescript": {
-          "version": "3.7.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-          "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+        "marked": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+          "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
           "dev": true
         }
       }
     },
     "typedoc-default-themes": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.3.tgz",
-      "integrity": "sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+      "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
       "dev": true,
       "requires": {
-        "backbone": "^1.4.0",
-        "jquery": "^3.4.1",
-        "lunr": "^2.3.8",
-        "underscore": "^1.9.1"
+        "lunr": "^2.3.8"
       }
     },
     "typedoc-plugin-lerna": {
@@ -9055,9 +9049,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uglify-js": {
@@ -9097,12 +9091,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
       "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
-      "dev": true
-    },
-    "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
       "dev": true
     },
     "union": {
@@ -9554,7 +9542,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -6,17 +6,19 @@
   ],
   "devDependencies": {
     "@lerna/bootstrap": "^3.18.4",
+    "@types/jasmine": "^3.5.10",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
     "@typescript-eslint/parser": "^2.7.0",
     "docsify-cli": "^4.4.0",
     "eslint": "^6.6.0",
     "http-server": "^0.12.3",
+    "jasmine": "^3.5.0",
     "jasmine-spec-reporter": "^5.0.2",
     "lerna": "^3.18.4",
     "ts-node": "^8.6.2",
-    "typedoc": "^0.15.4",
+    "typedoc": "^0.17.8",
     "typedoc-plugin-lerna": "^0.1.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.7"
   },
   "scripts": {
     "postinstall": "lerna bootstrap",
@@ -30,9 +32,5 @@
     "clean": "lerna run clean",
     "release": "lerna publish from-package --yes --no-verify-access",
     "beta-release": "lerna version prerelease --force-publish --yes && lerna publish --yes --no-verify-access --dist-tag beta"
-  },
-  "dependencies": {
-    "@types/jasmine": "^3.5.10",
-    "jasmine": "^3.5.0"
   }
 }

--- a/packages/costa/package-lock.json
+++ b/packages/costa/package-lock.json
@@ -26,6 +26,12 @@
 			"resolved": "https://registry.npm.alibaba-inc.com/@types/jasmine/download/@types/jasmine-3.5.10.tgz",
 			"integrity": "sha1-oaQQEgErXanUsgW6nrpY9sziq3s=",
 			"dev": true
+		},
+		"typescript": {
+			"version": "3.9.7",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"dev": true
 		}
 	}
 }

--- a/packages/pipboard/package-lock.json
+++ b/packages/pipboard/package-lock.json
@@ -16,6 +16,114 @@
 				"ini": "^1.3.5"
 			}
 		},
+		"@alifd/next": {
+			"version": "1.20.24",
+			"resolved": "https://registry.npmjs.org/@alifd/next/-/next-1.20.24.tgz",
+			"integrity": "sha512-ZOm+wl79VjRlQ8cso87TPwhzOejuV1yiiRpL35igfwA98sdXhKK3cLknvPJ2arkEpOiaHZcmPAtOWYRHGYN64Q==",
+			"requires": {
+				"@alifd/field": "~1.4.1",
+				"@alifd/validate": "~1.2.0",
+				"babel-runtime": "^6.26.0",
+				"classnames": "^2.2.3",
+				"hoist-non-react-statics": "^2.1.0",
+				"prop-types": "^15.6.0",
+				"react-lifecycles-compat": "^3.0.4",
+				"react-transition-group": "^2.2.1",
+				"shallow-element-equals": "^1.0.1"
+			},
+			"dependencies": {
+				"@alifd/field": {
+					"version": "1.4.4",
+					"resolved": "https://registry.npmjs.org/@alifd/field/-/field-1.4.4.tgz",
+					"integrity": "sha512-jv4iK2M1hM4v+SukT9ZgyVZEIL7grsl98tOQ9uF3p9RYP2LpBaAr34D9yY9k37C4z8sXs0kom/nJrXE5FZQgug==",
+					"requires": {
+						"@alifd/validate": "^1.2.0",
+						"prop-types": "^15.5.8"
+					}
+				},
+				"@alifd/validate": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/@alifd/validate/-/validate-1.2.0.tgz",
+					"integrity": "sha512-ZXzC9/2HnRAteeB6c0P9/DL8/lS69hhUiAAxS6GpFWKaQurtDUDiCQYNUWGv7zxaPGBaMxgPcfBBcFpgpaHF5w=="
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"requires": {
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
+					}
+				},
+				"classnames": {
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+					"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+				},
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+				},
+				"dom-helpers": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+					"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+					"requires": {
+						"@babel/runtime": "^7.1.2"
+					}
+				},
+				"hoist-non-react-statics": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				},
+				"react-lifecycles-compat": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+					"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+				},
+				"react-transition-group": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+					"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+					"requires": {
+						"dom-helpers": "^3.4.0",
+						"loose-envify": "^1.4.0",
+						"prop-types": "^15.6.2",
+						"react-lifecycles-compat": "^3.0.4"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				},
+				"shallow-element-equals": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/shallow-element-equals/-/shallow-element-equals-1.0.1.tgz",
+					"integrity": "sha1-UHObfZStdWehNBc9P0QiOH7VfOY=",
+					"requires": {
+						"style-equal": "^1.0.0"
+					}
+				},
+				"style-equal": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/style-equal/-/style-equal-1.0.0.tgz",
+					"integrity": "sha1-mKHFkiImv+E8GW5z8ZQOkbjmZZU="
+				}
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npm.alibaba-inc.com/@babel/code-frame/download/@babel/code-frame-7.8.3.tgz",
@@ -1245,7 +1353,6 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npm.alibaba-inc.com/@babel/runtime/download/@babel/runtime-7.9.2.tgz",
 			"integrity": "sha1-2Q3wWDo6JS8JqqYZZlNnuuUY2wY=",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -1253,8 +1360,7 @@
 				"regenerator-runtime": {
 					"version": "0.13.5",
 					"resolved": "https://registry.npm.alibaba-inc.com/regenerator-runtime/download/regenerator-runtime-0.13.5.tgz",
-					"integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc=",
-					"dev": true
+					"integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc="
 				}
 			}
 		},
@@ -1322,6 +1428,327 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
+			}
+		},
+		"@icedesign/container": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@icedesign/container/-/container-1.0.5.tgz",
+			"integrity": "sha512-/0ZNAKtntq2Agc7GjJZ3VytC9227CDgSwY1bmFbmGc9p7iGmcu7DiAe3CKPVyq51MNpksjlUWQGphVt7LkTMng==",
+			"requires": {
+				"@alifd/next": "^1.x",
+				"prop-types": "^15.5.8"
+			},
+			"dependencies": {
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				}
+			}
+		},
+		"@icedesign/img": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@icedesign/img/-/img-1.0.4.tgz",
+			"integrity": "sha512-XYepk984SGERhClKd/LnJwoWQ6LgAlqn64WTa/W2SMjmC5xRaAsC0bToZ3B8aoYmgG9sKpXVIFdWyNvThO3e1Q==",
+			"requires": {
+				"classnames": "^2.2.5",
+				"prop-types": "^15.5.10"
+			},
+			"dependencies": {
+				"classnames": {
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+					"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				}
+			}
+		},
+		"@icedesign/layout": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@icedesign/layout/-/layout-1.0.8.tgz",
+			"integrity": "sha512-qwZT33cGpfwCbOU8fwHZpD8KNT7Pm+sw/Sbe3PypEepohE1vKSxFR8VnfOswY1xG5Ba//F8w6VQzlPlJnStv/Q==",
+			"requires": {
+				"@alifd/next": "^1.11.7",
+				"classnames": "^2.2.5",
+				"prop-types": "^15.5.10"
+			},
+			"dependencies": {
+				"classnames": {
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+					"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				}
+			}
+		},
+		"@icedesign/notification": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@icedesign/notification/-/notification-1.0.5.tgz",
+			"integrity": "sha512-dLuZ+Iec8+CQMUqEk1SIxtVb/FOf05QUNrMJSHFf9hYQqw+VgEgbdQ1KuqB8sP+/mgKmEd7MIzGykcRS7clGFg==",
+			"requires": {
+				"@alifd/next": "^1.x",
+				"rc-notification": "^1.4.2"
+			},
+			"dependencies": {
+				"add-dom-event-listener": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz",
+					"integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
+					"requires": {
+						"object-assign": "4.x"
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"requires": {
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
+					}
+				},
+				"classnames": {
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+					"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+				},
+				"component-classes": {
+					"version": "1.2.6",
+					"resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
+					"integrity": "sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=",
+					"requires": {
+						"component-indexof": "0.0.3"
+					}
+				},
+				"component-indexof": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
+					"integrity": "sha1-EdCRMSI5648yyPJa6csAL/6NPCQ="
+				},
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+				},
+				"css-animation": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.6.1.tgz",
+					"integrity": "sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==",
+					"requires": {
+						"babel-runtime": "6.x",
+						"component-classes": "^1.2.5"
+					}
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				},
+				"raf": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+					"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+					"requires": {
+						"performance-now": "^2.1.0"
+					}
+				},
+				"rc-animate": {
+					"version": "2.11.1",
+					"resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.11.1.tgz",
+					"integrity": "sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==",
+					"requires": {
+						"babel-runtime": "6.x",
+						"classnames": "^2.2.6",
+						"css-animation": "^1.3.2",
+						"prop-types": "15.x",
+						"raf": "^3.4.0",
+						"rc-util": "^4.15.3",
+						"react-lifecycles-compat": "^3.0.4"
+					}
+				},
+				"rc-notification": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-1.4.3.tgz",
+					"integrity": "sha1-Tq6FgHvX5a7hyJJ6XJvrr+Tld4c=",
+					"requires": {
+						"babel-runtime": "^6.23.0",
+						"classnames": "2.x",
+						"prop-types": "^15.5.8",
+						"rc-animate": "2.x",
+						"rc-util": "4.x"
+					}
+				},
+				"rc-util": {
+					"version": "4.21.1",
+					"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.21.1.tgz",
+					"integrity": "sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==",
+					"requires": {
+						"add-dom-event-listener": "^1.1.0",
+						"prop-types": "^15.5.10",
+						"react-is": "^16.12.0",
+						"react-lifecycles-compat": "^3.0.4",
+						"shallowequal": "^1.1.0"
+					}
+				},
+				"react-lifecycles-compat": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+					"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				},
+				"shallowequal": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+					"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+				}
+			}
+		},
+		"@icedesign/theme": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@icedesign/theme/-/theme-1.2.1.tgz",
+			"integrity": "sha512-zkusZcfdVmIDveNusgGuSIGlBDf+PUMAYeuYl/F4cQxfGsK1xHWp9HfBLwAsw0JN1hJVDyrQz6gyopbYSUwYUg==",
+			"requires": {
+				"@alifd/next": "~1.19.19"
+			},
+			"dependencies": {
+				"@alifd/field": {
+					"version": "1.3.5",
+					"resolved": "https://registry.npmjs.org/@alifd/field/-/field-1.3.5.tgz",
+					"integrity": "sha512-wLUPHTjpVJ7XamisaVP6ZTVtjPkIPk2xIj/gD2vdzcvUk3SSNhENh7d2bASIQe6XoYvEuwy9pg2DvsiaSU0wZQ==",
+					"requires": {
+						"@alifd/validate": "^1.1.3",
+						"prop-types": "^15.5.8"
+					}
+				},
+				"@alifd/next": {
+					"version": "1.19.31",
+					"resolved": "https://registry.npmjs.org/@alifd/next/-/next-1.19.31.tgz",
+					"integrity": "sha512-Vl2oXlX2Ahe/0UgAsgFqLzGKj87kBTPcCaSiN+jSVLVXgOMQXw03dBGkHYIWYojKS9H9lk+wDiEL7aiizh5ATA==",
+					"requires": {
+						"@alifd/field": "~1.3.3",
+						"@alifd/validate": "~1.1.4",
+						"babel-runtime": "^6.26.0",
+						"classnames": "^2.2.3",
+						"hoist-non-react-statics": "^2.1.0",
+						"prop-types": "^15.6.0",
+						"react-lifecycles-compat": "^3.0.4",
+						"react-transition-group": "^2.2.1",
+						"shallow-element-equals": "^1.0.1"
+					}
+				},
+				"@alifd/validate": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/@alifd/validate/-/validate-1.1.5.tgz",
+					"integrity": "sha512-uinc+qLTrgKtGzXIkbit8spHLe17fzxAeXYe6ND5AgqqnhvZ4IAmZEClrE8HhaZ4QfnsaYR9MDx8CaagpQ+Y3A=="
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"requires": {
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
+					}
+				},
+				"classnames": {
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+					"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+				},
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+				},
+				"dom-helpers": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+					"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+					"requires": {
+						"@babel/runtime": "^7.1.2"
+					}
+				},
+				"hoist-non-react-statics": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				},
+				"react-lifecycles-compat": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+					"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+				},
+				"react-transition-group": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+					"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+					"requires": {
+						"dom-helpers": "^3.4.0",
+						"loose-envify": "^1.4.0",
+						"prop-types": "^15.6.2",
+						"react-lifecycles-compat": "^3.0.4"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				},
+				"shallow-element-equals": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/shallow-element-equals/-/shallow-element-equals-1.0.1.tgz",
+					"integrity": "sha1-UHObfZStdWehNBc9P0QiOH7VfOY=",
+					"requires": {
+						"style-equal": "^1.0.0"
+					}
+				},
+				"style-equal": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/style-equal/-/style-equal-1.0.0.tgz",
+					"integrity": "sha1-mKHFkiImv+E8GW5z8ZQOkbjmZZU="
+				}
 			}
 		},
 		"@jest/console": {
@@ -8513,8 +8940,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npm.alibaba-inc.com/js-tokens/download/js-tokens-4.0.0.tgz",
-			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
-			"dev": true
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -8854,7 +9280,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npm.alibaba-inc.com/loose-envify/download/loose-envify-1.4.0.tgz",
 			"integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -9956,8 +10381,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npm.alibaba-inc.com/object-assign/download/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -10436,8 +10860,7 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npm.alibaba-inc.com/performance-now/download/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"picomatch": {
 			"version": "2.2.2",
@@ -11736,8 +12159,7 @@
 		"react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npm.alibaba-inc.com/react-is/download/react-is-16.13.1.tgz",
-			"integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
-			"dev": true
+			"integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ="
 		},
 		"readable-stream": {
 			"version": "3.6.0",

--- a/packages/pipboard/package.json
+++ b/packages/pipboard/package.json
@@ -9,7 +9,7 @@
     "@icedesign/layout": "^1.x",
     "@icedesign/notification": "^1.0.5",
     "@icedesign/theme": "^1.0.0",
-    "@tensorflow/tfjs": "^2.0.1",
+    "@tensorflow/tfjs": "1.7.0",
     "axios": "^0.18.1",
     "classnames": "^2.2.5",
     "codemirror": "^5.52.2",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -20,6 +20,12 @@
 					"dev": true
 				}
 			}
+		},
+		"typescript": {
+			"version": "3.9.7",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"dev": true
 		}
 	}
 }


### PR DESCRIPTION
This fixes #344, and the `node_modules` result is:

| before | after |
|--------|------|
| 1.3G | 826M |