### PR TITLE
CI/CD: fix beta release skipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typedoc": "typedoc",
     "clean": "lerna run clean",
     "release": "lerna publish from-package --yes --no-verify-access",
-    "beta-release": "lerna version prerelease --force-publish --yes && lerna publish --yes --no-verify-access --dist-tag beta"
+    "beta-release": "lerna version prerelease --force-publish=* --yes && lerna publish from-git --yes --no-verify-access --dist-tag beta"
   },
   "dependencies": {
     "@types/jasmine": "^3.5.10",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typedoc": "typedoc",
     "clean": "lerna run clean",
     "release": "lerna publish from-package --yes --no-verify-access",
-    "beta-release": "lerna version prerelease --force-publish=* --yes && lerna publish from-git --yes --no-verify-access --dist-tag beta"
+    "beta-release": "lerna version prerelease --force-publish=* --yes && lerna publish from-package  --preid beta --yes --no-verify-access --dist-tag beta"
   },
   "dependencies": {
     "@types/jasmine": "^3.5.10",


### PR DESCRIPTION
This PR fixes the skipping behavior for `beta` release.
And changed the preid for beta release to `beta`