### PR TITLE
boa: fix redownload pybind11 when execute `lerna add`

### DIFF
--- a/packages/boa/pybind11/Makefile
+++ b/packages/boa/pybind11/Makefile
@@ -27,7 +27,6 @@ $(BUILD):
 	$(MD5CMD)
 	tar -C $(DOWNLOAD_DIR) -xf $(TARBALL)
 	mv $(ARCHIVE_DIR) $(BUILD)
-	rm -rf $(DOWNLOAD_DIR)
 
 clean:
 	rm -rf $(BUILD)


### PR DESCRIPTION
When I execute `$ learn add some-package --scope @pipcook/pipcook-core`, the dependence of boa `pybind11` was downloaded again.