### PR TITLE
build: re-installation takes too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typescript": "^3.9.7"
   },
   "scripts": {
+    "preinstall": "lerna clean --yes",
     "postinstall": "lerna bootstrap",
     "build": "lerna run compile",
     "docsify": "npm run typedoc && http-server -c-1 ./docs",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "typescript": "^3.9.7"
   },
   "scripts": {
-    "preinstall": "lerna clean --yes",
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna clean --yes && lerna bootstrap",
     "build": "lerna run compile",
     "docsify": "npm run typedoc && http-server -c-1 ./docs",
     "lint": "eslint . --ext .ts --ext .js && lerna run --scope @pipcook/daemon --scope @pipcook/pipboard lint",


### PR DESCRIPTION
This PR adds `clean` ahead of install process to avoid extremely long `prune hoisting ` time.
For more detail, please refer to this issue https://github.com/lerna/lerna/issues/602