### PR TITLE
CI/CD: Fix prerelease

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Publish npm beta packages
         if: env.UPDATED == 'true'
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          sha_short=$(git rev-parse --short HEAD)"
           echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" > ~/.npmrc
           git config --global user.name 'pipcook'
           git config --global user.email 'queyue.crk@alibaba-inc.com'

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -55,7 +55,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" > ~/.npmrc
           git config --global user.name 'pipcook'
           git config --global user.email 'queyue.crk@alibaba-inc.com'
-          npm run beta-release-tag "${sha_short}-beta"
+          npm run beta-release-tag -- --preid "${sha_short}-beta"
           npm run beta-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -54,6 +54,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" > ~/.npmrc
           git config --global user.name 'pipcook'
           git config --global user.email 'queyue.crk@alibaba-inc.com'
+          npm run beta-release-tag env.GITHUB_RUN_NUMBER
           npm run beta-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -51,10 +51,11 @@ jobs:
       - name: Publish npm beta packages
         if: env.UPDATED == 'true'
         run: |
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" > ~/.npmrc
           git config --global user.name 'pipcook'
           git config --global user.email 'queyue.crk@alibaba-inc.com'
-          npm run beta-release-tag env.GITHUB_RUN_NUMBER
+          npm run beta-release-tag "${sha_short}-beta"
           npm run beta-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
     "clean": "lerna run clean",
     "release": "lerna publish from-package --yes --no-verify-access",
     "beta-release-tag": "lerna version prerelease --no-push --force-publish=* --yes  --preid ",
-    "beta-release": "lerna publish from-package --yes --no-verify-access --dist-tag beta"  }
+    "beta-release": "lerna publish from-package --yes --no-verify-access --dist-tag beta"  
+  }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typedoc": "typedoc",
     "clean": "lerna run clean",
     "release": "lerna publish from-package --yes --no-verify-access",
-    "beta-release": "lerna version prerelease --preid beta --force-publish=* --yes && lerna publish from-package --yes --no-verify-access --dist-tag beta"
-  }
+    "beta-release-tag": "lerna version prerelease --force-publish=* --yes  --preid ",
+    "beta-release": "lerna publish from-package --yes --no-verify-access --dist-tag beta"  }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typedoc": "typedoc",
     "clean": "lerna run clean",
     "release": "lerna publish from-package --yes --no-verify-access",
-    "beta-release-tag": "lerna version prerelease --force-publish=* --yes  --preid ",
+    "beta-release-tag": "lerna version prerelease --no-push --force-publish=* --yes  --preid ",
     "beta-release": "lerna publish from-package --yes --no-verify-access --dist-tag beta"  }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typedoc": "typedoc",
     "clean": "lerna run clean",
     "release": "lerna publish from-package --yes --no-verify-access",
-    "beta-release-tag": "lerna version prerelease --no-push --force-publish=* --yes  --preid ",
+    "beta-release-tag": "lerna version prerelease --no-push --force-publish=* --yes",
     "beta-release": "lerna publish from-package --yes --no-verify-access --dist-tag beta"  
   }
 }


### PR DESCRIPTION
This pr uses `build_id` instead of `beta` as the preid to fix the package name issue