### PR TITLE
plugins: lock the version of python dependencies

### DIFF
--- a/packages/costa/test/plugins/python-simple/package.json
+++ b/packages/costa/test/plugins/python-simple/package.json
@@ -14,7 +14,7 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "numpy": "*"
+      "numpy": "1.19.1"
     }
   }
 }

--- a/packages/plugins/data-process/tensorflow-image-classification-process/package.json
+++ b/packages/plugins/data-process/tensorflow-image-classification-process/package.json
@@ -34,7 +34,7 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "tensorflow": "*"
+      "tensorflow": "2.2.0"
     }
   }
 }

--- a/packages/plugins/model-define/bayesian-model-define/package.json
+++ b/packages/plugins/model-define/bayesian-model-define/package.json
@@ -34,8 +34,8 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "jieba": "*",
-      "scikit-learn": "*"
+      "jieba": "0.42.1",
+      "scikit-learn": "0.23.2"
     }
   }
 }

--- a/packages/plugins/model-define/detectron-fasterrcnn-model-define/package.json
+++ b/packages/plugins/model-define/detectron-fasterrcnn-model-define/package.json
@@ -38,7 +38,7 @@
     "dependencies": {
       "torch": "1.4.0",
       "torchvision": "0.5.0",
-      "opencv-python": "*",
+      "opencv-python": "4.3.0.36",
       "cython": "*",
       "pycocotools": "*",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"

--- a/packages/plugins/model-define/detectron-fasterrcnn-model-define/package.json
+++ b/packages/plugins/model-define/detectron-fasterrcnn-model-define/package.json
@@ -39,8 +39,8 @@
       "torch": "1.4.0",
       "torchvision": "0.5.0",
       "opencv-python": "4.3.0.36",
-      "cython": "*",
-      "pycocotools": "*",
+      "cython": "0.29.21",
+      "pycocotools": "2.0.1",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"
     }
   }

--- a/packages/plugins/model-define/detectron-fasterrcnn-model-define/package.json
+++ b/packages/plugins/model-define/detectron-fasterrcnn-model-define/package.json
@@ -38,7 +38,7 @@
     "dependencies": {
       "torch": "1.4.0",
       "torchvision": "0.5.0",
-      "opencv-python": "4.3.0.36",
+      "opencv-python": "4.2.0.34",
       "cython": "0.29.21",
       "pycocotools": "2.0.1",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"

--- a/packages/plugins/model-define/detectron-maskrcnn-model-define/package.json
+++ b/packages/plugins/model-define/detectron-maskrcnn-model-define/package.json
@@ -38,8 +38,8 @@
       "torch": "1.4.0",
       "torchvision": "0.5.0",
       "opencv-python": "4.3.0.36",
-      "cython": "*",
-      "pycocotools": "*",
+      "cython": "0.29.21",
+      "pycocotools": "2.0.1",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"
     }
   },

--- a/packages/plugins/model-define/detectron-maskrcnn-model-define/package.json
+++ b/packages/plugins/model-define/detectron-maskrcnn-model-define/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
       "torch": "1.4.0",
       "torchvision": "0.5.0",
-      "opencv-python": "4.3.0.36",
+      "opencv-python": "4.2.0.34",
       "cython": "0.29.21",
       "pycocotools": "2.0.1",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"

--- a/packages/plugins/model-define/detectron-maskrcnn-model-define/package.json
+++ b/packages/plugins/model-define/detectron-maskrcnn-model-define/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
       "torch": "1.4.0",
       "torchvision": "0.5.0",
-      "opencv-python": "*",
+      "opencv-python": "4.3.0.36",
       "cython": "*",
       "pycocotools": "*",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"

--- a/packages/plugins/model-define/tensorflow-cycle-gan-model-define/package.json
+++ b/packages/plugins/model-define/tensorflow-cycle-gan-model-define/package.json
@@ -32,7 +32,7 @@
     "python": "3.7",
     "dependencies": {
       "tensorflow": "*",
-      "opencv-python": "*"
+      "opencv-python": "4.3.0.36"
     }
   }
 }

--- a/packages/plugins/model-define/tensorflow-cycle-gan-model-define/package.json
+++ b/packages/plugins/model-define/tensorflow-cycle-gan-model-define/package.json
@@ -31,7 +31,7 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "tensorflow": "*",
+      "tensorflow": "2.2.0",
       "opencv-python": "4.3.0.36"
     }
   }

--- a/packages/plugins/model-define/tensorflow-cycle-gan-model-define/package.json
+++ b/packages/plugins/model-define/tensorflow-cycle-gan-model-define/package.json
@@ -32,7 +32,7 @@
     "python": "3.7",
     "dependencies": {
       "tensorflow": "2.2.0",
-      "opencv-python": "4.3.0.36"
+      "opencv-python": "4.2.0.34"
     }
   }
 }

--- a/packages/plugins/model-define/tensorflow-mobilenet-model-define/package.json
+++ b/packages/plugins/model-define/tensorflow-mobilenet-model-define/package.json
@@ -36,7 +36,7 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "tensorflow": "*"
+      "tensorflow": "2.2.0"
     }
   }
 }

--- a/packages/plugins/model-define/tensorflow-resnet-model-define/package.json
+++ b/packages/plugins/model-define/tensorflow-resnet-model-define/package.json
@@ -36,7 +36,7 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "tensorflow": "*"
+      "tensorflow": "2.2.0"
     }
   }
 }

--- a/packages/plugins/model-evaluate/bayesian-model-evaluate/package.json
+++ b/packages/plugins/model-evaluate/bayesian-model-evaluate/package.json
@@ -36,8 +36,8 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "jieba": "*",
-      "scikit-learn": "*"
+      "jieba": "0.42.1",
+      "scikit-learn": "0.23.2"
     }
   }
 }

--- a/packages/plugins/model-evaluate/detectron-model-evaluate/package.json
+++ b/packages/plugins/model-evaluate/detectron-model-evaluate/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
       "torch": "1.4.0",
       "torchvision": "0.5.0",
-      "opencv-python": "4.3.0.36",
+      "opencv-python": "4.2.0.34",
       "cython": "0.29.21",
       "pycocotools": "2.0.1",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"

--- a/packages/plugins/model-evaluate/detectron-model-evaluate/package.json
+++ b/packages/plugins/model-evaluate/detectron-model-evaluate/package.json
@@ -37,8 +37,8 @@
       "torch": "1.4.0",
       "torchvision": "0.5.0",
       "opencv-python": "4.3.0.36",
-      "cython": "*",
-      "pycocotools": "*",
+      "cython": "0.29.21",
+      "pycocotools": "2.0.1",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"
     }
   }

--- a/packages/plugins/model-evaluate/detectron-model-evaluate/package.json
+++ b/packages/plugins/model-evaluate/detectron-model-evaluate/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
       "torch": "1.4.0",
       "torchvision": "0.5.0",
-      "opencv-python": "*",
+      "opencv-python": "4.3.0.36",
       "cython": "*",
       "pycocotools": "*",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"

--- a/packages/plugins/model-evaluate/image-classification-tensorflow-model-evaluate/package.json
+++ b/packages/plugins/model-evaluate/image-classification-tensorflow-model-evaluate/package.json
@@ -31,7 +31,7 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "tensorflow": "*"
+      "tensorflow": "2.2.0"
     }
   }
 }

--- a/packages/plugins/model-load/tensorflow-model-load/package.json
+++ b/packages/plugins/model-load/tensorflow-model-load/package.json
@@ -34,7 +34,7 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "tensorflow": "*"
+      "tensorflow": "2.2.0"
     }
   }
 }

--- a/packages/plugins/model-train/bayesian-model-train/package.json
+++ b/packages/plugins/model-train/bayesian-model-train/package.json
@@ -38,8 +38,8 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "jieba": "*",
-      "scikit-learn": "*"
+      "jieba": "0.42.1",
+      "scikit-learn": "0.23.2"
     }
   }
 }

--- a/packages/plugins/model-train/detectron-model-train/package.json
+++ b/packages/plugins/model-train/detectron-model-train/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
       "torch": "1.4.0",
       "torchvision": "0.5.0",
-      "opencv-python": "4.3.0.36",
+      "opencv-python": "4.2.0.34",
       "cython": "0.29.21",
       "pycocotools": "2.0.1",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"

--- a/packages/plugins/model-train/detectron-model-train/package.json
+++ b/packages/plugins/model-train/detectron-model-train/package.json
@@ -37,8 +37,8 @@
       "torch": "1.4.0",
       "torchvision": "0.5.0",
       "opencv-python": "4.3.0.36",
-      "cython": "*",
-      "pycocotools": "*",
+      "cython": "0.29.21",
+      "pycocotools": "2.0.1",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"
     }
   }

--- a/packages/plugins/model-train/detectron-model-train/package.json
+++ b/packages/plugins/model-train/detectron-model-train/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
       "torch": "1.4.0",
       "torchvision": "0.5.0",
-      "opencv-python": "*",
+      "opencv-python": "4.3.0.36",
       "cython": "*",
       "pycocotools": "*",
       "detectron": "git+https://gitee.com/pipcook/detectron2.git"

--- a/packages/plugins/model-train/image-classification-tensorflow-model-train/package.json
+++ b/packages/plugins/model-train/image-classification-tensorflow-model-train/package.json
@@ -33,7 +33,7 @@
   "conda": {
     "python": "3.7",
     "dependencies": {
-      "tensorflow": "*"
+      "tensorflow": "2.2.0"
     }
   }
 }


### PR DESCRIPTION
The latest version of opencv-python is 4.3.0.38, but it costs too much time to build, so we lock it at 4.3.0.36.