### PR TITLE
daemon, costa: remove the installation action for job run

### DIFF
--- a/packages/daemon/src/app/controller/pipeline.ts
+++ b/packages/daemon/src/app/controller/pipeline.ts
@@ -150,15 +150,17 @@ export class PipelineController extends BaseEventController {
       if (!pipeline[type]) {
         continue;
       }
+      let plugin = await this.pluginManager.findByName(pipeline[type]);
+      if (plugin && plugin.status === PluginStatus.INSTALLED) {
+        log.stdout.writeLine(`plugin ${plugin.name}@${plugin.version} already installed`);
+        continue;
+      }
       debug(`start installation: ${type}`);
       const pkg = await this.pluginManager.fetch(pipeline[type]);
-      log.stdout.writeLine(`start to install plugin ${pkg.name}@${pkg.version}`);
+      log.stdout.writeLine(`start to install plugin ${pkg.name}`);
 
       debug(`installing ${pipeline[type]}.`);
-      const plugin = await this.pluginManager.findOrCreateByPkg(pkg);
-      if (plugin.status === PluginStatus.INSTALLED) {
-        return log.stdout.writeLine(`plugin ${pkg.name}@${pkg.version} already installed`);
-      }
+      plugin = await this.pluginManager.findOrCreateByPkg(pkg);
       try {
         await this.pluginManager.install(pkg, {
           pyIndex,

--- a/packages/daemon/src/service/pipeline.ts
+++ b/packages/daemon/src/service/pipeline.ts
@@ -194,7 +194,7 @@ export class PipelineService {
     if (noneInstalledPlugins.length > 0) {
       const errStr = noneInstalledPlugins.map((value: string, index: number) => {
         return index === noneInstalledPlugins.length - 1 ? value : `${value}, `;
-      })
+      });
       throw createHttpError(HttpStatus.NOT_FOUND, `these plugins are not installed: ${errStr}`);
     }
     return plugins;

--- a/packages/daemon/src/service/plugin.ts
+++ b/packages/daemon/src/service/plugin.ts
@@ -32,6 +32,13 @@ export class PluginManager {
     return this.pluginRT.costa.fetch(name);
   }
 
+  /**
+   * fetch pakcage info by plugin name
+   * @param name plugin name
+   */
+  async fetchFromInstalledPlugin(name: string): Promise<PluginPackage> {
+    return this.pluginRT.costa.fetchFromInstalledPlugin(name);
+  }
   async fetchByStream(stream: NodeJS.ReadableStream): Promise<PluginPackage> {
     return this.pluginRT.costa.fetchByStream(stream);
   }
@@ -105,8 +112,8 @@ export class PluginManager {
   async findOrCreateByPkg(pkg: PluginPackage): Promise<PluginModel> {
     const [ plugin ] = await this.model.findOrCreate({
       where: {
-        name: pkg.name,
-        version: pkg.version
+        // TODO(feely): support the different versions of plugins
+        name: pkg.name
       },
       defaults: {
         id: generateId(),


### PR DESCRIPTION
If any plugin is not installed, `daemon` will throw 404 error with the message includes the uninstalled plugin list.