### PR TITLE
cli: fix run a pipeline config without download

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -63,9 +63,11 @@ jobs:
     - name: pipcook run from local filename
       run: |
         ./packages/cli/dist/bin/pipcook run ./test/pipelines/text-bayes-classification.json
+        ls ./output && rm -rf ./output
     - name: pipcook run from url
       run: |
         ./packages/cli/dist/bin/pipcook run https://raw.githubusercontent.com/alibaba/pipcook/master/example/pipelines/text-bayes-classification.json
+        ls ./output && rm -rf ./output
     - name: pipcook plugin install
       run: |
         ./packages/cli/dist/bin/pipcook plugin install ./packages/plugins/data-collect/csv-data-collect

--- a/packages/cli/src/bin/pipcook.ts
+++ b/packages/cli/src/bin/pipcook.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
 import { constants } from '@pipcook/pipcook-core';
 import { pathExists } from 'fs-extra';
 
-import { start } from '../service/job';
+import { runAndDownload } from '../service/job';
 import init from '../actions/init';
 import serve from '../actions/serve';
 import board from '../actions/board';
@@ -63,7 +63,7 @@ import devPlugin from '../actions/dev-plugin';
     .option('-h|--host-ip <ip>', 'the host ip of daemon')
     .option('-p|--port <port>', 'the port of daemon')
     .description('run pipeline with a json file.')
-    .action(start);
+    .action(runAndDownload);
 
   program
     .command('serve <dir>')

--- a/packages/cli/src/service/job.ts
+++ b/packages/cli/src/service/job.ts
@@ -112,10 +112,6 @@ export async function run(filename: string, opts: any): Promise<JobResp> {
   }
 }
 
-export async function start(filename: string, opts: any): Promise<void> {
-  await run(filename, opts);
-}
-
 export async function runAndDownload(filename: string, opts: any) {
   const job = await run(filename, opts);
   const client = initClient(opts.ip, opts.port);


### PR DESCRIPTION
Bug fix:
The command `pipcook run <config file>` did not download the output.