### PR TITLE
daemon: preinstall sequelize-cli for migration

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -20,6 +20,7 @@
     "midway": "^1.19.0",
     "request-promise": "^4.2.5",
     "sequelize": "^5.21.7",
+    "sequelize-cli": "^6.2.0",
     "sqlite3": "^4.1.1",
     "ssestream": "^1.1.0"
   },


### PR DESCRIPTION
Fix: #449 

### Benchmark
MacOS Catalina 10.15.5 MacBook Pro (16-inch, 2019)
Node: v12.17.0

#### Before:
```shell
$ node ./packages/daemon/bootstrap.js
npx: 80 安装成功，用时 30.633 秒
single process mode is still in experiment, please don't use it in production environment
Server is listening at http://localhost:6927, cost 35.354666849s
```
#### After:
```shell
$ node ./packages/daemon/bootstrap.js
single process mode is still in experiment, please don't use it in production environment
Server is listening at http://localhost:6927, cost 3.240450431s
```