### PR TITLE
cli: init plugin with boa and core

### DIFF
--- a/packages/cli/src/actions/init.ts
+++ b/packages/cli/src/actions/init.ts
@@ -1,13 +1,13 @@
-import { join, dirname } from 'path';
+import { join } from 'path';
 import { execSync as exec } from 'child_process';
-import fse, { readJson, ensureDir, symlink, remove } from 'fs-extra';
+import fse, { readJson, writeJson, ensureDir, symlink, remove, pathExists } from 'fs-extra';
 import { prompt } from 'inquirer';
 import { sync } from 'command-exists';
 import { constants as CoreConstants } from '@pipcook/pipcook-core';
 
 import { Constants, logger } from '../utils/common';
 import { InitCommandHandler } from '../types';
-import { optionalNpmClients, daemonPackage, boardPackage, isLocal } from '../config';
+import { optionalNpmClients, daemonPackage, boardPackage } from '../config';
 
 const {
   BOA_CONDA_INDEX,
@@ -16,21 +16,54 @@ const {
 
 async function npmInstall(npmClient: string, name: string, beta: boolean, cwd: string, env: NodeJS.ProcessEnv): Promise<void> {
   exec(`"${npmClient}" init -f`, { cwd, env, stdio: 'ignore' });
-  if (isLocal) {
-    // FIXME(yorkie): manually make symlink to local development
-    // This is because npm-install from path will not be compatible with lerna's node_modules/.staging dir.
-    const pkg = await readJson(name + '/package.json');
-    const dest = join(cwd, 'node_modules', pkg.name);
-    await ensureDir(dirname(dest));
-    await symlink(name, dest, 'dir');
-  } else {
-    if (beta) {
-      name = `${name}@beta`;
-    }
-    const cmd = `"${npmClient}" install ${name} -E --production`;
-    console.info(`exec "${cmd}"`);
-    exec(cmd, { cwd, env, stdio: 'inherit' });
+  if (beta) {
+    name = `${name}@beta`;
   }
+  const cmd = `"${npmClient}" install ${name} -E --production`;
+  exec(cmd, { cwd, env, stdio: 'inherit' });
+}
+
+/**
+ * init the plugin project with boa and core
+ */
+async function initPlugin(daemonDir: string, pluginDir: string) {
+  await ensureDir(pluginDir);
+  if (!await pathExists(join(pluginDir, 'package.json'))) {
+    exec('npm init -y', { cwd: pluginDir, stdio: 'ignore' });
+  }
+
+  if (!await pathExists(daemonDir)) {
+    return logger.warn('daemon is not installed.');
+  }
+  let boa = join(daemonDir, 'node_modules/@pipcook/boa');
+  if (!await pathExists(boa)) {
+    boa = join(daemonDir, 'node_modules/@pipcook/daemon/node_modules/@pipcook/costa/node_modules/@pipcook/boa');
+    if (!await pathExists(boa)) {
+      return logger.warn('boa is not installed.');
+    }
+  }
+  let core = join(daemonDir, 'node_modules/@pipcook/pipcook-core');
+  if (!await pathExists(core)) {
+    core = join(daemonDir, 'node_modules/@pipcook/daemon/node_modules/@pipcook/pipcook-core');
+    if (!await pathExists(core)) {
+      return logger.warn('pipcook-core is not installed.');
+    }
+  }
+  await ensureDir(join(pluginDir, 'node_modules/@pipcook'));
+  const boaPlugin = join(pluginDir, 'node_modules/@pipcook/boa');
+  const corePlugin = join(pluginDir, 'node_modules/@pipcook/core');
+  const pluginPackage = await readJson(join(pluginDir, 'package.json'));
+  if (!await pathExists(boaPlugin)) {
+    await symlink(boa, boaPlugin);
+    const boaPackage = await readJson(join(boaPlugin, 'package.json'));
+    pluginPackage.dependencies[boaPackage.name] = boaPackage.version;
+  }
+  if (!await pathExists(corePlugin)) {
+    await symlink(core, corePlugin);
+    const corePackage = await readJson(join(corePlugin, 'package.json'));
+    pluginPackage.dependencies[corePackage.name] = corePackage.version;
+  }
+  await writeJson(join(pluginDir, 'package.json'), pluginPackage, { spaces: 2 });
 }
 
 /**
@@ -97,7 +130,8 @@ const init: InitCommandHandler = async ({ client, beta, tuna }) => {
       npmInstall(npmClient, daemonPackage, beta, CoreConstants.PIPCOOK_DAEMON, npmInstallEnvs),
       npmInstall(npmClient, boardPackage, beta, CoreConstants.PIPCOOK_BOARD, npmInstallEnvs)
     ]);
-    await fse.copy(CoreConstants.PIPCOOK_BOARD_BUILD, CoreConstants.PIPCOOK_DAEMON_PUBLIC);
+    await initPlugin(CoreConstants.PIPCOOK_DAEMON, CoreConstants.PIPCOOK_PLUGINS);
+    // await fse.copy(CoreConstants.PIPCOOK_BOARD_BUILD, CoreConstants.PIPCOOK_DAEMON_PUBLIC);
     logger.success('Pipcook is ready, you can try "pipcook --help" to get started.');
   } catch (err) {
     logger.fail(`failed to initialize Pipcook with the error ${err && err.stack}`, false);

--- a/packages/cli/src/actions/init.ts
+++ b/packages/cli/src/actions/init.ts
@@ -131,7 +131,7 @@ const init: InitCommandHandler = async ({ client, beta, tuna }) => {
       npmInstall(npmClient, boardPackage, beta, CoreConstants.PIPCOOK_BOARD, npmInstallEnvs)
     ]);
     await initPlugin(CoreConstants.PIPCOOK_DAEMON, CoreConstants.PIPCOOK_PLUGINS);
-    // await fse.copy(CoreConstants.PIPCOOK_BOARD_BUILD, CoreConstants.PIPCOOK_DAEMON_PUBLIC);
+    await fse.copy(CoreConstants.PIPCOOK_BOARD_BUILD, CoreConstants.PIPCOOK_DAEMON_PUBLIC);
     logger.success('Pipcook is ready, you can try "pipcook --help" to get started.');
   } catch (err) {
     logger.fail(`failed to initialize Pipcook with the error ${err && err.stack}`, false);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -4,7 +4,7 @@ export const dependencies: string[] = [
 ];
 
 export const daemonPackage = '@pipcook/daemon';
-export const boardPackage ='@pipcook/pipboard';
+export const boardPackage = '@pipcook/pipboard';
 
 export const pipcookLogName = 'pipcook-output';
 export const optionalNpmClients: string[] = [ 'npm', 'cnpm' ];

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,13 +1,10 @@
-import path from 'path';
-
 export const dependencies: string[] = [
   '@pipcook/boa',
   '@pipcook/pipcook-core'
 ];
 
-export const isLocal = process.env.NODE_ENV === 'local';
-export const daemonPackage = isLocal ? path.join(__dirname, '../../daemon') : '@pipcook/daemon';
-export const boardPackage = isLocal ? path.join(__dirname, '../../pipboard') : '@pipcook/pipboard';
+export const daemonPackage = '@pipcook/daemon';
+export const boardPackage ='@pipcook/pipboard';
 
 export const pipcookLogName = 'pipcook-output';
 export const optionalNpmClients: string[] = [ 'npm', 'cnpm' ];


### PR DESCRIPTION
Speed up the plugin installation.

Benchmark:
Before: 1.16s user 0.26s system 0% cpu 4:08.73 total
```shell
$ time ./packages/cli/dist/bin/pipcook pipeline install ./example/pipelines/text-bayes-classification.json --tuna
ℹ Wrote to /path/.pipcook/plugins/package.json:
ℹ fetching package info @pipcook/plugins-csv-data-collect
ℹ {
ℹ   "name": "plugins",
ℹ   "version": "1.0.0",
ℹ   "description": "",
ℹ   "main": "index.js",
ℹ   "scripts": {
ℹ     "test": "echo \"Error: no test specified\" && exit 1"
ℹ   },
ℹ   "keywords": [],
ℹ   "author": "",
ℹ   "license": "ISC"
ℹ }
ℹ fetching package info @pipcook/plugins-csv-data-collect
ℹ fetching package info @pipcook/plugins-csv-data-collect
......
ℹ check plugin:
✔ @pipcook/plugins-csv-data-collect installed.
✔ @pipcook/plugins-csv-data-access installed.
✔ @pipcook/plugins-bayesian-model-define installed.
✔ @pipcook/plugins-bayesian-model-train installed.
✔ @pipcook/plugins-bayesian-model-evaluate installed.
✔ pipeline installed successfully.
./packages/cli/dist/bin/pipcook pipeline install  --tuna  1.16s user 0.26s system 0% cpu 4:08.73 total
```
After: 1.02s user 0.24s system 2% cpu 1:00.28 total
```shell
 time ./packages/cli/dist/bin/pipcook pipeline install ./example/pipelines/text-bayes-classification.json --tuna
ℹ fetching package info @pipcook/plugins-bayesian-model-evaluate
ℹ > @tensorflow/tfjs-node-gpu@1.7.0 install /path/.pipcook/plugins/node_modules/@tensorflow/tfjs-node-gpu
ℹ > node scripts/install.js gpu download
ℹ fetching package info @pipcook/plugins-bayesian-model-evaluate
ℹ GPU-darwin-1.7.0.tar.gz
⚠ * Downloading libtensorflow
⚠ fetching package info @pipcook/plugins-bayesian-model-evaluate
⚠ * Building TensorFlow Node.js bindings
ℹ fetching package info @pipcook/plugins-bayesian-model-evaluate
ℹ > nodejieba@2.4.1 install /path/.pipcook/plugins/node_modules/nodejieba
ℹ > node-pre-gyp install --fallback-to-build
ℹ fetching package info @pipcook/plugins-bayesian-model-evaluate
⚠ node-pre-gyp WARN Using request for node-pre-gyp https download 
⚠ node-pre-gyp WARN Tried to download(404): https://github.com/yanyiwu/nodejieba/releases/download/2.4.1/nodejieba-v2.4.1-node-v72-darwin-x64.tar.gz 
⚠ node-pre-gyp WARN Pre-built binaries not found for nodejieba@2.4.1 and node@12.17.0 (node-v72 ABI, unknown) (falling back to source compile with node-gyp) 
ℹ   CXX(target) Release/obj.target/nodejieba/lib/index.o
ℹ   CXX(target) Release/obj.target/nodejieba/lib/nodejieba.o
⚠ In file included from ../lib/nodejieba.cpp:3:
⚠ In file included from ../deps/cppjieba/Jieba.hpp:4:
⚠ In file included from ../deps/cppjieba/QuerySegment.hpp:8:
⚠ In file included from ../deps/cppjieba/DictTrie.hpp:13:
⚠ ../deps/limonp/StringUtil.hpp:87:70: warning: 'ptr_fun<unsigned int, bool>' is deprecated [-Wdeprecated-declarations]
⚠   s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<unsigned, bool>(IsSpace))));
⚠                                                                      ^
⚠ /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/functional:1100:1: note: 'ptr_fun<unsigned int, bool>' has been explicitly marked deprecated here
⚠ _LIBCPP_DEPRECATED_IN_CXX11 inline _LIBCPP_INLINE_VISIBILITY
⚠ ^
⚠ /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/__config:1054:39: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX11'
⚠ #  define _LIBCPP_DEPRECATED_IN_CXX11 _LIBCPP_DEPRECATED
⚠                                       ^
⚠ /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/__config:1043:48: note: expanded from macro '_LIBCPP_DEPRECATED'
......
ℹ check plugin:
✔ @pipcook/plugins-csv-data-collect installed.
✔ @pipcook/plugins-csv-data-access installed.
✔ @pipcook/plugins-bayesian-model-define installed.
✔ @pipcook/plugins-bayesian-model-train installed.
✔ @pipcook/plugins-bayesian-model-evaluate installed.
✔ pipeline installed successfully.
./packages/cli/dist/bin/pipcook pipeline install  --tuna  1.02s user 0.24s system 2% cpu 1:00.28 total
```
