### PR TITLE
costa: install Node and Python packages in parallel

### DIFF
--- a/packages/costa/benchmark/makefile
+++ b/packages/costa/benchmark/makefile
@@ -2,3 +2,5 @@ export DEBUG=costa*
 
 bootstrap:
 	time node ./bootstrap.js
+install:
+	time node ./plugin-install.js

--- a/packages/costa/benchmark/plugin-install.js
+++ b/packages/costa/benchmark/plugin-install.js
@@ -11,7 +11,6 @@ const costa = new CostaRuntime({
 });
 
 (async () => {
-  const start = Date.now();
   const pkg = await costa.fetch('@pipcook/plugins-tensorflow-resnet-model-define');
   await costa.install(pkg, process);
 })();

--- a/packages/costa/benchmark/plugin-install.js
+++ b/packages/costa/benchmark/plugin-install.js
@@ -2,7 +2,6 @@
 
 const { join } = require('path');
 const { CostaRuntime } = require('../dist/src/runtime');
-const { PluginRunnable } = require('../dist/src/runnable');
 
 const costa = new CostaRuntime({
   installDir: join(__dirname, '../.tests/plugins'),
@@ -10,9 +9,9 @@ const costa = new CostaRuntime({
   componentDir: join(__dirname, '../.tests/components'),
   npmRegistryPrefix: 'https://registry.npmjs.com/'
 });
-const r = new PluginRunnable(costa);
 
 (async () => {
-  await r.bootstrap({});
-  r.destroy();
+  const start = Date.now();
+  const pkg = await costa.fetch('@pipcook/plugins-tensorflow-resnet-model-define');
+  await costa.install(pkg, process);
 })();

--- a/packages/costa/src/runtime.ts
+++ b/packages/costa/src/runtime.ts
@@ -293,7 +293,7 @@ export class CostaRuntime {
   /**
    * install node packages for plugin
    * @param pkg plugin package info
-   * @param opts install options
+   * @param optsinstall options
    */
   private async installNodeModules(pkg: PluginPackage, opts: InstallOptions): Promise<void> {
     const pluginStdName = `${pkg.name}@${pkg.version}`;
@@ -305,7 +305,7 @@ export class CostaRuntime {
       pluginAbsName = pkg.pipcook.source.uri;
       debug(`install the plugin from ${pluginAbsName}`);
     }
-    const stdio = { stdout: opts.stdout, stderr: opts.stderr, prefix: 'node' };
+    const stdio = { stdout: opts.stdout, stderr: opts.stderr, prefix: 'NODE' };
     const npmExecOpts = { cwd: this.options.installDir };
     const npmArgs = [ 'install', pluginAbsName, '-E', '--production' ];
 
@@ -316,14 +316,14 @@ export class CostaRuntime {
       // if not init for plugin directory, just run `npm init` and install boa firstly.
       await spawnAsync('npm', [ 'init', '-y' ], npmExecOpts, stdio);
     }
-    return spawnAsync('npm', npmArgs, npmExecOpts, { ...stdio, prefix: 'NODE' });
+    return spawnAsync('npm', npmArgs, npmExecOpts, stdio);
   }
 
   /**
    * install python packages for plugin
    * @param pkg plugin package info
    * @param boaSrcPath boa source path
-   * @param opts install options
+   * @param optsinstall options
    */
   private async installPythonPackages(pkg: PluginPackage, boaSrcPath: string, opts: InstallOptions): Promise<void> {
     if (pkg.conda?.dependencies) {

--- a/packages/costa/src/utils.ts
+++ b/packages/costa/src/utils.ts
@@ -1,6 +1,7 @@
 export interface LogStdio {
   stdout: NodeJS.WritableStream;
   stderr: NodeJS.WritableStream;
+  prefix?: string;
 }
 
 /**
@@ -8,13 +9,24 @@ export interface LogStdio {
  * Readable.pipi() will close the target pipe when end, we should ignore the end event.
  * @param readable child process stdout/stderr
  * @param writable the log stream
+ * @param prefix the log prefix
  */
-export function pipeLog(readable: NodeJS.ReadableStream, writable: NodeJS.WritableStream): void {
+export function pipeLog(readable: NodeJS.ReadableStream, writable: NodeJS.WritableStream, prefix?: string): void {
+  let buffer = '';
   readable.on('error', (err) => {
     writable.emit('error', err);
   });
-  readable.on('data', async (data) => {
-    writable.write(data);
+  readable.on('data', (data) => {
+    if (prefix) {
+      buffer += data.toString();
+      const list = buffer.split(/\n|\r/);
+      buffer = list.pop();
+      list.forEach((log) => {
+        writable.write(`${prefix}: ${log}\n`);
+      });
+    } else {
+      writable.write(data);
+    }
   });
 }
 


### PR DESCRIPTION
Benchmark:
Test command:
```shell
$ time ./packages/cli/dist/bin/pipcook plugin install @pipcook/plugins-tensorflow-resnet-model-define --tuna
```

This plugin depends on `tensorflow@2.2.0`.

| Branch                       | Test A          | Test B          | Test C          | Test D          | AVG             |
| ---------------------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
| master                       | 1 m 20.06 s | 1 m 19.86 s | 1 m 25.03 s | 1 m 18.33 s | 1 m 20.82 s |
| modify/parallel-installation | 1 m 11.06 s | 1 m 04.47 s | 1 m 04.92 s | 1 m 11.27 s | 1 m 07.93 s |

In this typical scenario, reduced installation time by 15%.