### PR TITLE
daemon: fix plugin status

### DIFF
--- a/packages/daemon/src/service/plugin.ts
+++ b/packages/daemon/src/service/plugin.ts
@@ -132,7 +132,7 @@ export class PluginManager {
   async install(pluginId: string, pkg: PluginPackage, opts: InstallOptions): Promise<void> {
     return new Promise((resolve, reject) => {
       pluginQueue.push((cb) => {
-        this.setStatusById(pluginId, PluginStatus.PENDING);
+        this.setStatusById(pluginId, PluginStatus.INSTALLING);
         this.pluginRT.costa.install(pkg, opts).then(() => {
           resolve();
           cb();

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,4 +1,4 @@
 // FIXME(feely): move these to core
 export const tunaMirrorURI = 'https://pypi.tuna.tsinghua.edu.cn/simple';
 export const JobStatusValue = [ 'creating', 'running', 'success', 'fail', 'canceled' ];
-export const PluginStatusValue = [ 'installing', 'installed', 'failed' ];
+export const PluginStatusValue = [ 'installing', 'installed', 'failed', 'pending' ];


### PR DESCRIPTION
The plugin status is missing if the plugin is installing or pending by command `pipcook plugin list`.