### PR TITLE
add: cancel workflow when new push arrived

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ jobs:
         node_version: ['12', '14']
         os: [ubuntu-latest, macOS-latest]
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.4.1
+      with:
+        access_token: ${{ github.token }}
     - uses: actions/checkout@v2
     - name: restore lerna
       uses: actions/cache@v2


### PR DESCRIPTION
The old commit is still running when new commit arrived, it's not necessary.
This PR cancel will cancel the previous runs by new push.
