### PR TITLE
daemon: avoid generating d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "^3.9.7"
   },
   "scripts": {
-    "build": "lerna run compile && rm ./packages/daemon/dist/migrations/*.d.ts",
+    "build": "lerna run compile",
     "dev-build": "lerna run dev-compile --parallel --concurrency 10",
     "postinstall": "lerna clean --yes && lerna bootstrap && node ./tools/init_dev.js -f",
     "docsify": "npm run typedoc && http-server -c-1 ./docs",

--- a/packages/daemon/tsconfig.json
+++ b/packages/daemon/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedLocals": true,
     "stripInternal": true,
     "pretty": true,
-    "declaration": true,
+    "declaration": false,
     "outDir": "dist",
     "skipLibCheck": true
   },


### PR DESCRIPTION
Daemon is an executable so that the d.ts is unnecessary, this PR sets declaration to `false` to avoid this.