### PR TITLE
daemon: enable cors for ng-pipboard

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -26,6 +26,7 @@
         "node-addon-api",
         "midway",
         "egg-ci",
+        "egg-cors",
         "egg-scripts",
         "midway-bin",
         "midway-mock",

--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -150,6 +150,14 @@
 				"@hapi/hoek": "^9.0.0"
 			}
 		},
+		"@koa/cors": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.1.0.tgz",
+			"integrity": "sha512-7ulRC1da/rBa6kj6P4g2aJfnET3z8Uf3SWu60cjbtxTA5g8lxRdX/Bd2P92EagGwwAhANeNw8T8if99rJliR6Q==",
+			"requires": {
+				"vary": "^1.1.2"
+			}
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -2145,6 +2153,14 @@
 					"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
 					"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
 				}
+			}
+		},
+		"egg-cors": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/egg-cors/-/egg-cors-2.2.3.tgz",
+			"integrity": "sha512-MLG4pQekZpycLXR45ZAIgFpFYshosBxu1CMdhXAzqPzxUn0xI21gVzqLqcxUrzzulaErCwG6qMXaS1eFyj9u2w==",
+			"requires": {
+				"@koa/cors": "^3.0.0"
 			}
 		},
 		"egg-development": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -11,6 +11,7 @@
     "cls-hooked": "^4.2.2",
     "debug": "^4.1.1",
     "egg": "^2.26.1",
+    "egg-cors": "^2.2.3",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
     "glob-promise": "^3.4.0",

--- a/packages/daemon/src/config/config.default.ts
+++ b/packages/daemon/src/config/config.default.ts
@@ -20,6 +20,11 @@ export default (appInfo: EggAppInfo) => {
     'errorHandler'
   ];
 
+  config.cors = {
+    origin: '*',
+    allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH'
+  };
+
   config.security = {
     csrf: {
       enable: false,

--- a/packages/daemon/src/config/plugin.ts
+++ b/packages/daemon/src/config/plugin.ts
@@ -1,4 +1,13 @@
-import { EggPlugin } from 'midway';
 export default {
-  static: true // default is true
-} as EggPlugin;
+  static: true,
+  cors: {
+    enable: true,
+    package: 'egg-cors'
+  },
+  security: {
+    domainWhiteList: [
+      'http://localhost:4444',
+      'https://pipboard.vercel.app'
+    ]
+  }
+};

--- a/packages/daemon/src/config/plugin.ts
+++ b/packages/daemon/src/config/plugin.ts
@@ -6,7 +6,7 @@ export default {
   },
   security: {
     domainWhiteList: [
-      'http://localhost:4444',
+      'http://localhost',
       'https://pipboard.vercel.app'
     ]
   }


### PR DESCRIPTION
Our next-generation board will be an absolute web-based application, so we need a CORS setting on daemon for that access to the local/remote Pipcook via SDK.