### PR TITLE
cli: avoid generating d.ts

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "resolveJsonModule": true,
+    "composite": false,
     "declaration": false,
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "resolveJsonModule": true,
+    "declaration": false,
     "outDir": "./dist",
     "rootDir": "./src"
   },


### PR DESCRIPTION
See #494, the cli might not need these declaration files.