### PR TITLE
sdk: specify files in package to avoid tsconfig error

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.2",
   "description": "JavaScript SDK for accessing Pipcook Daemon",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "package-lock.json"
+  ],
   "scripts": {
     "build": "npm run clean && npm run compile",
     "dev-build": "npm run clean && npm run dev-compile",


### PR DESCRIPTION
Without this, the TypeScript language service would give an error on the `tsconfig.json` because "../../tsconfig.json" is not found.