### PR TITLE
fix python runtime

### DIFF
--- a/packages/costa/src/client/loaders/python.ts
+++ b/packages/costa/src/client/loaders/python.ts
@@ -3,7 +3,7 @@ const boa = require('@pipcook/boa');
 const sys = boa.import('sys');
 
 export default function (pkg: PluginPackage): Function {
-  const fn = boa.import(`node_modules.${pkg.name}`);
+  const fn = boa.import(`node_modules.${pkg.name.replace(/\//g, '.')}`);
   return (...args: any[]) => {
     const res = fn.main(...args);
 

--- a/packages/costa/test/plugins/python-scope/__init__.py
+++ b/packages/costa/test/plugins/python-scope/__init__.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+def main(input):
+  print('hello python!', input)
+  return np.zeros(10)

--- a/packages/costa/test/plugins/python-scope/package.json
+++ b/packages/costa/test/plugins/python-scope/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@abc/python-simple",
+  "version": "1.0.0",
+  "description": "test python simple",
+  "main": "__init__.py",
+  "dependencies": {
+    "@pipcook/boa": "^1.0.4"
+  },
+  "pipcook": {
+    "category": "modelDefine",
+    "datatype": "text",
+    "runtime": "python"
+  },
+  "conda": {
+    "python": "3.7",
+    "dependencies": {
+      "numpy": "1.19.1"
+    }
+  }
+}

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -86,6 +86,25 @@ describe('start runnable in normal way', () => {
     expect(stdout2.search('hello python! [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]') !== 0).toBe(true);
   });
 
+  it('should start a python plugin with scope package name', async () => {
+    await mkdirp(path.join(__dirname, './plugins/python-scope/node_modules/@pipcook'));
+    if (await pathExists(path.join(__dirname, './plugins/python-scope/node_modules/@pipcook/boa'))) {
+      await remove(path.join(__dirname, './plugins/python-scope/node_modules/@pipcook/boa'));
+    }
+    await symlink(
+      path.join(__dirname, '../../../boa'),
+      path.join(__dirname, './plugins/python-scope/node_modules/@pipcook/boa')
+    );
+    const simple = await costa.fetch(path.join(__dirname, '../../test/plugins/python-scope'));
+    const stdoutStream = new StringWritable();
+    const stderrStream = new StringWritable();
+    await costa.install(simple, { stdout: stdoutStream, stderr: stderrStream });
+    // test if the plugin is executed successfully
+    await runnable.start(simple, tmp);
+    const stdout = stdoutStream.data;
+    expect(stdout.search('hello python!') !== 0).toBe(true);
+  });
+
   it('should destroy the runnable', async () => {
     await runnable.destroy();
     const list = await readdir(costa.options.componentDir);


### PR DESCRIPTION
When the plugin specifies 'python' runtime, boa will try to import plugin's entry python file. 

Right now it imports like:

```
const fn = boa.import(`node_modules.${pkg.name}`);
```

However, if the plugin name includes scope, for instance:

```
@pipcook/ner_model
```

the contents inside import will be

```
node_modules.@pipcook/ner_model
```

The right way to import should be:

```
node_modules.@pipcook.ner_model
```

This PR is to fix this