### PR TITLE
fix: child process not exits with unhandled rejection

### DIFF
--- a/packages/costa/src/client/entry.ts
+++ b/packages/costa/src/client/entry.ts
@@ -202,3 +202,7 @@ process.on('message', (msg): void => {
   const proto = PluginProtocol.parse(msg);
   handlers[proto.op](proto);
 });
+
+process.on('unhandledRejection', (reason) => {
+  throw reason;
+});

--- a/packages/costa/src/client/entry.ts
+++ b/packages/costa/src/client/entry.ts
@@ -203,6 +203,9 @@ process.on('message', (msg): void => {
   handlers[proto.op](proto);
 });
 
+// if any error occurrs by promise chain in `nextTick`,
+// the error will be thrown from event `unhandledRejection`,
+// we need to handle and throw it out. Otherwise, this process will not exit.
 process.on('unhandledRejection', (reason) => {
   throw reason;
 });

--- a/packages/costa/src/client/entry.ts
+++ b/packages/costa/src/client/entry.ts
@@ -206,6 +206,7 @@ process.on('message', (msg): void => {
 // if any error occurrs by promise chain in `nextTick`,
 // the error will be thrown from event `unhandledRejection`,
 // we need to handle and throw it out. Otherwise, this process will not exit.
+// see #523 for details.
 process.on('unhandledRejection', (reason) => {
   throw reason;
 });


### PR DESCRIPTION
Costa process should handle the promise reject in nextTick.

### Before
```shell
ℹ start loading plugin @pipcook/plugins-image-classification-data-collect
ℹ downloading dataset ...
ℹ unzip and collecting data...
ℹ create annotation file...
ℹ start loading plugin @pipcook/plugins-pascalvoc-data-access
ℹ create a result "1dbgsib6" for plugin "@pipcook/plugins-pascalvoc-data-access@1.1.0"
ℹ start loading plugin @pipcook/plugins-image-data-process
ℹ start loading plugin @pipcook/plugins-tensorflow-mobilenet-model-define
⚠ (node:55539) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'data' of undefined
⚠     at DataLoader.<anonymous> (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:63:47)
⚠     at Generator.next (<anonymous>)
⚠     at /path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:31:71
⚠     at new Promise (<anonymous>)
⚠     at __awaiter (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:27:12)
⚠     at DataLoader.setItem (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:62:16)
⚠     at /path/to/pipcook/packages/costa/dist/src/client/entry.js:126:42
⚠     at Generator.next (<anonymous>)
⚠     at fulfilled (/path/to/pipcook/packages/costa/dist/src/client/entry.js:24:58)
⚠     at processTicksAndRejections (internal/process/task_queues.js:97:5)
⚠ (node:55539) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
⚠ (node:55539) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
⚠ (node:55539) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'data' of undefined
⚠     at DataLoader.<anonymous> (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:63:47)
⚠     at Generator.next (<anonymous>)
⚠     at /path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:31:71
⚠     at new Promise (<anonymous>)
⚠     at __awaiter (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:27:12)
⚠     at DataLoader.setItem (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:62:16)
⚠     at /path/to/pipcook/packages/costa/dist/src/client/entry.js:126:42
⚠     at Generator.next (<anonymous>)
⚠     at fulfilled (/path/to/pipcook/packages/costa/dist/src/client/entry.js:24:58)
⚠     at processTicksAndRejections (internal/process/task_queues.js:97:5)
⚠ (node:55539) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 4)
⚠ (node:55539) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'data' of undefined
⚠     at DataLoader.<anonymous> (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:63:47)
⚠     at Generator.next (<anonymous>)
⚠     at /path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:31:71
⚠     at new Promise (<anonymous>)
⚠     at __awaiter (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:27:12)
⚠     at DataLoader.setItem (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:62:16)
⚠     at /path/to/pipcook/packages/costa/dist/src/client/entry.js:126:42
⚠     at Generator.next (<anonymous>)
⚠     at fulfilled (/path/to/pipcook/packages/costa/dist/src/client/entry.js:24:58)
⚠     at processTicksAndRejections (internal/process/task_queues.js:97:5)
⚠ (node:55539) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 6)
```
### After
```shell
ℹ start loading plugin @pipcook/plugins-image-classification-data-collect
ℹ downloading dataset ...
ℹ unzip and collecting data...
ℹ create annotation file...
ℹ start loading plugin @pipcook/plugins-pascalvoc-data-access
ℹ create a result "lnvjltdl" for plugin "@pipcook/plugins-pascalvoc-data-access@1.1.0"
ℹ start loading plugin @pipcook/plugins-image-data-process
ℹ start loading plugin @pipcook/plugins-tensorflow-mobilenet-model-define
⚠ /path/to/pipcook/packages/costa/dist/src/client/entry.js:227
⚠     throw reason;
⚠     ^
⚠ fetching package info @pipcook/plugins-image-classification-tensorflow-model-evaluate
⚠ TypeError: Cannot read property 'data' of undefined
⚠     at DataLoader.<anonymous> (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:63:47)
⚠     at Generator.next (<anonymous>)
⚠     at /path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:31:71
⚠     at new Promise (<anonymous>)
⚠     at __awaiter (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:27:12)
⚠     at DataLoader.setItem (/path/to/.pipcook/plugins/node_modules/@pipcook/plugins-pascalvoc-data-access/dist/index.js:62:16)
⚠     at /path/to/pipcook/packages/costa/dist/src/client/entry.js:126:42
⚠     at Generator.next (<anonymous>)
⚠     at fulfilled (/path/to/pipcook/packages/costa/dist/src/client/entry.js:24:58)
⚠     at processTicksAndRejections (internal/process/task_queues.js:97:5)
✖ something wrong when run job: costa runtime is destroyed(null).
```