### PR TITLE
cli: fix job pending status missing

### DIFF
--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,4 +1,4 @@
 // FIXME(feely): move these to core
 export const tunaMirrorURI = 'https://pypi.tuna.tsinghua.edu.cn/simple';
-export const JobStatusValue = [ 'creating', 'running', 'success', 'fail', 'canceled' ];
+export const JobStatusValue = [ 'creating', 'running', 'success', 'fail', 'canceled', 'pending' ];
 export const PluginStatusValue = [ 'installing', 'installed', 'failed', 'pending', 'initialized' ];


### PR DESCRIPTION
```sh
┌─────────┬────────────┬────────────┬───────────┬──────────────┬────────────────────────────┐
│ (index) │     id     │ pipelineId │  status   │ evaluatePass │         createdAt          │
├─────────┼────────────┼────────────┼───────────┼──────────────┼────────────────────────────┤
│    0    │ 'tvc9wx0e' │ 'ho86xso5' │ undefined │     null     │ '2020-09-03T12:17:49.977Z' │
│    1    │ 'a9dcm7ny' │ '8v59hnhe' │ 'running' │     null     │ '2020-09-03T12:17:43.038Z' │
└─────────┴────────────┴────────────┴───────────┴──────────────┴────────────────────────────┘
```