### PR TITLE
daemon: fix pipeline create

### DIFF
--- a/packages/daemon/src/app/controller/pipeline.ts
+++ b/packages/daemon/src/app/controller/pipeline.ts
@@ -43,8 +43,12 @@ export class PipelineController extends BaseEventController {
     // the plugin name could be git/web url, we need the real name, and create plugin object
     const createPlugin = async (field: string) => {
       if (parsedConfig[field]) {
-        const pkg = await this.pluginManager.fetch(parsedConfig[field]);
-        return this.pluginManager.findOrCreateByPkg(pkg);
+        let plugin = await this.pluginManager.findByName(parsedConfig[field]);
+        if (!plugin || plugin.status !== PluginStatus.INSTALLED) {
+          const pkg = await this.pluginManager.fetch(parsedConfig[field]);
+          plugin = await this.pluginManager.findOrCreateByPkg(pkg);
+        }
+        return plugin;
       }
     };
     const plugins = [];

--- a/packages/daemon/test/controller/pipeline.test.ts
+++ b/packages/daemon/test/controller/pipeline.test.ts
@@ -96,9 +96,20 @@ describe('test pipeline controller', () => {
         };
       }
     });
+    app.mockClassFunction('pluginManager', 'findByName', async (name: string) => {
+      const nameList = [ 'dataCollect', 'dataAccess' ];
+      assert.ok(nameList.indexOf(name) >= 0);
+      if (name === 'dataCollect') {
+        return {
+          id: 'dataCollectInstalled',
+          name: 'dataCollect',
+          status: 1
+        };
+      }
+    });
     app.mockClassFunction('pipelineService', 'createPipeline', async (pipeline: PipelineDB) => {
       assert.equal(pipeline.name, 'name');
-      assert.equal(pipeline.dataCollectId, 'dataCollectId');
+      assert.equal(pipeline.dataCollectId, 'dataCollectInstalled');
       assert.equal(pipeline.dataCollect, 'dataCollect');
       assert.equal(pipeline.dataCollectParams, '{"testParam":"123"}');
       assert.equal(pipeline.dataAccessId, 'dataAccessId');
@@ -131,14 +142,14 @@ describe('test pipeline controller', () => {
       .expect(201).then((res) => {
         assert.equal(res.body.id, 'id');
         assert.equal(res.body.name, 'name');
-        assert.equal(res.body.dataCollectId, 'dataCollectId');
+        assert.equal(res.body.dataCollectId, 'dataCollectInstalled');
         assert.equal(res.body.dataCollect, 'dataCollect');
         assert.equal(res.body.dataCollectParams, '{"testParam":"123"}');
         assert.equal(res.body.dataAccessId, 'dataAccessId');
         assert.equal(res.body.dataAccess, 'dataAccess');
         assert.equal(res.body.dataAccessParams, '{"testParam":"456"}');
         assert.deepEqual(res.body.plugins, [
-          {id: 'dataCollectId', name: 'dataCollect'},
+          {id: 'dataCollectInstalled', name: 'dataCollect', status: 1},
           {id: 'dataAccessId', name: 'dataAccess'}
         ]);
       });


### PR DESCRIPTION
If run a pipeline with plugins which from http url, there will be a 404 error from npm.