### PR TITLE
daemon: add tests for job download

### DIFF
--- a/packages/daemon/src/app/controller/job.ts
+++ b/packages/daemon/src/app/controller/job.ts
@@ -1,7 +1,7 @@
 import { controller, inject, provide, get, post, del } from 'midway';
 import * as HttpStatus from 'http-status';
 import { constants, PipelineStatus } from '@pipcook/pipcook-core';
-import { createReadStream, ensureDir, ensureFile } from 'fs-extra';
+import { createReadStream, ensureDir, ensureFile, pathExists } from 'fs-extra';
 import { join } from 'path';
 import { BaseEventController } from './base';
 import { PipelineService } from '../../service/pipeline';
@@ -112,6 +112,9 @@ export class JobController extends BaseEventController {
       this.ctx.throw(HttpStatus.BAD_REQUEST, 'invalid job status');
     }
     const outputPath = this.pipelineService.getOutputTarByJobId(this.ctx.params.id);
+    if (!await pathExists(outputPath)) {
+      this.ctx.throw(HttpStatus.BAD_REQUEST, 'output file not found');
+    }
     this.ctx.attachment(`pipcook-output-${this.ctx.params.id}.tar.gz`);
     this.ctx.body = createReadStream(outputPath);
   }

--- a/packages/daemon/src/app/controller/job.ts
+++ b/packages/daemon/src/app/controller/job.ts
@@ -1,6 +1,6 @@
 import { controller, inject, provide, get, post, del } from 'midway';
 import * as HttpStatus from 'http-status';
-import { constants } from '@pipcook/pipcook-core';
+import { constants, PipelineStatus } from '@pipcook/pipcook-core';
 import { createReadStream, ensureDir, ensureFile } from 'fs-extra';
 import { join } from 'path';
 import { BaseEventController } from './base';
@@ -107,6 +107,10 @@ export class JobController extends BaseEventController {
 
   @get('/:id/output')
   public async download(): Promise<void> {
+    const job = await this.pipelineService.getJobById(this.ctx.params.id);
+    if (job.status !== PipelineStatus.SUCCESS) {
+      this.ctx.throw(HttpStatus.BAD_REQUEST, 'invalid job status');
+    }
     const outputPath = this.pipelineService.getOutputTarByJobId(this.ctx.params.id);
     this.ctx.attachment(`pipcook-output-${this.ctx.params.id}.tar.gz`);
     this.ctx.body = createReadStream(outputPath);

--- a/packages/daemon/test/controller/job.test.ts
+++ b/packages/daemon/test/controller/job.test.ts
@@ -1,7 +1,12 @@
 import { app, assert } from 'midway-mock/bootstrap';
 import * as HttpStatus from 'http-status';
 import * as createHttpError from 'http-errors';
+import { PipelineStatus } from '@pipcook/pipcook-core';
+import { join } from 'path';
+import * as fs from 'fs-extra';
+import * as sinon from 'sinon';
 
+const sandbox = sinon.createSandbox();
 let mockPipeline = {
   id: '',
   name: 'pipeline-name',
@@ -47,6 +52,9 @@ const mockJob = {
 const mockPlugins = [ { id: '123' }, { id: '456' } ];
 
 describe('test job controller', () => {
+  beforeEach(function () {
+    sandbox.restore();
+});
   it('should list jobs', () => {
     return app
       .httpRequest()
@@ -87,6 +95,40 @@ describe('test job controller', () => {
         assert.equal(typeof resp.body.traceId, 'string');
       })
       .expect(200);
+  });
+  it('should download job', () => {
+    app.mockClassFunction('pipelineService', 'getJobById', async (id: string) => {
+      assert.equal(id, 'job-id');
+      return { status: PipelineStatus.SUCCESS };
+    });
+    app.mockClassFunction('pipelineService', 'getOutputTarByJobId', (id: string) => {
+      assert.equal(id, 'job-id');
+      return join(__dirname, 'job.test.ts');
+    });
+    const mockCreateReadStream = sandbox.stub(fs, 'createReadStream');
+    return app
+      .httpRequest()
+      .get('/api/job/job-id/output')
+      .expect('content-disposition', 'attachment; filename="pipcook-output-job-id.tar.gz"')
+      .expect(async (resp) => {
+        console.log(resp.header);
+        sandbox.assert.calledOnceWithExactly(mockCreateReadStream, join(__dirname, 'job.test.ts'));
+      })
+      .expect(204);
+  });
+  it('download a invalid job', () => {
+    app.mockClassFunction('pipelineService', 'getJobById', async (id: string) => {
+      assert.equal(id, 'job-id');
+      return { status: PipelineStatus.FAIL };
+    });
+    return app
+      .httpRequest()
+      .get('/api/job/job-id/output')
+      .expect('Content-Type', /json/)
+      .expect(async (resp) => {
+        assert.equal(resp.body.message, 'invalid job status');
+      })
+      .expect(400);
   });
   it('should throw error run a uninstalled job', () => {
     app.mockClassFunction('pipelineService', 'getPipeline', async (id: string) => {


### PR DESCRIPTION
Fix: if a job is not successful, or the output file not exists, the api `download` should return 400 and error message.
And add tests for it.