### PR TITLE
daemon: improve coverage for controller

### DIFF
--- a/packages/daemon/src/app/controller/job.ts
+++ b/packages/daemon/src/app/controller/job.ts
@@ -47,7 +47,7 @@ export class JobController extends BaseEventController {
       });
       this.ctx.success({ ...(job.toJSON() as JobResp), traceId: tracer.id });
     } else {
-      this.ctx.throw(HttpStatus.NOT_FOUND, 'not pipeline found');
+      this.ctx.throw(HttpStatus.NOT_FOUND, 'no pipeline found');
     }
   }
 

--- a/packages/daemon/test/controller/index.test.ts
+++ b/packages/daemon/test/controller/index.test.ts
@@ -1,4 +1,4 @@
-import { app } from 'midway-mock/bootstrap';
+import { app, assert } from 'midway-mock/bootstrap';
 import { constants } from '@pipcook/pipcook-core';
 import * as fse from 'fs-extra';
 import * as sinon from 'sinon';
@@ -8,6 +8,15 @@ describe('test index controller', () => {
     sinon.restore();
   });
 
+  it('should fetch index', () => {
+    return app
+      .httpRequest()
+      .get('/')
+      .expect('Content-Type', /html/)
+      .expect(302).expect(res => {
+        assert.equal(res.header['location'], '/index.html');
+      });
+  });
   it('should view versions', () => {
     return app
       .httpRequest()

--- a/packages/daemon/test/controller/job.test.ts
+++ b/packages/daemon/test/controller/job.test.ts
@@ -1,4 +1,4 @@
-import { app, assert } from 'midway-mock/bootstrap';
+import { app, assert, mm } from 'midway-mock/bootstrap';
 import * as HttpStatus from 'http-status';
 import * as createHttpError from 'http-errors';
 import { PipelineStatus } from '@pipcook/pipcook-core';
@@ -54,7 +54,8 @@ const mockPlugins = [ { id: '123' }, { id: '456' } ];
 describe('test job controller', () => {
   beforeEach(function () {
     sandbox.restore();
-});
+    mm.restore();
+  });
   it('should list jobs', () => {
     return app
       .httpRequest()
@@ -64,6 +65,145 @@ describe('test job controller', () => {
         assert.equal(Array.isArray(resp.body), true);
       })
       .expect(200);
+  });
+
+  it('should get job info', () => {
+    app.mockClassFunction('pipelineService', 'getJobById', async (id: string) => {
+      assert.equal(id, 'id');
+      return mockJob;
+    });
+    return app
+      .httpRequest()
+      .get('/api/job/id')
+      .expect('Content-Type', /json/)
+      .expect((resp) => {
+        assert.equal(resp.body.id, mockJob.id);
+      })
+      .expect(200);
+  });
+
+  it('get nonexistent job info', () => {
+    app.mockClassFunction('pipelineService', 'getJobById', async (id: string) => {
+      assert.equal(id, 'id');
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .get('/api/job/id')
+      .expect(404);
+  });
+
+  it('should trace event', () => {
+    app.mockClassFunction('traceManager', 'get', (id): any => {
+      assert.equal(id, 'trace-id');
+      let callback;
+      return {
+        listen: (cb) => {
+          callback = cb;
+        },
+        wait: async () => {
+          return callback({ type: 'mock type', data: 'mock data' });
+        }
+      }
+    });
+    return app
+      .httpRequest()
+      .get('/api/job/event/trace-id')
+      .expect(200).expect((res) => {
+        console.log('trace res', res.text);
+        assert.ok((res.text as string).indexOf('mock type') >= 0);
+        assert.ok((res.text as string).indexOf('mock data') >= 0);
+      });
+  });
+
+  it('should delete job by id', () => {
+    app.mockClassFunction('pipelineService', 'removeJobById', async (id: string) => {
+      assert.equal(id, 'id');
+      return 1;
+    });
+    return app
+      .httpRequest()
+      .del('/api/job/id')
+      .expect(204);
+  });
+
+  it('should delete all jobs', () => {
+    let called = false;
+    app.mockClassFunction('pipelineService', 'removeJobs', () => {
+      called = true;
+    });
+    return app
+      .httpRequest()
+      .del('/api/job')
+      .expect(204).expect(() => {
+        assert.ok(called);
+      });
+  });
+
+  it('delete nonexistent job', () => {
+    app.mockClassFunction('pipelineService', 'removeJobById', async (id: string) => {
+      assert.equal(id, 'id');
+      return 0;
+    });
+    return app
+      .httpRequest()
+      .del('/api/job/id')
+      .expect(404);
+  });
+
+  it('should cancel job by id', () => {
+    app.mockClassFunction('pipelineService', 'stopJob', async (id: string) => {
+      assert.equal(id, 'id');
+    });
+    return app
+      .httpRequest()
+      .post('/api/job/id/cancel')
+      .expect(204);
+  });
+
+  it('cancel job with error', () => {
+    app.mockClassFunction('pipelineService', 'stopJob', async (id: string) => {
+      assert.equal(id, 'id');
+      throw new TypeError('mock error');
+    });
+    return app
+      .httpRequest()
+      .post('/api/job/id/cancel')
+      .expect(500);
+  });
+
+  it('should get job log by id', () => {
+    const logs = [
+      '1', 
+      '2'
+    ];
+    app.mockClassFunction('pipelineService', 'getJobById', async (id: string) => {
+      assert.equal(id, 'id');
+      return {
+        id: 'id'
+      }
+    });
+    app.mockClassFunction('pipelineService', 'getLogById', async (id: string) => {
+      assert.equal(id, 'id');
+      return logs;
+    });
+    return app
+      .httpRequest()
+      .get('/api/job/id/log')
+      .expect(200).expect((res) => {
+        assert.deepEqual(res.body, logs);
+      });
+  });
+
+  it('get nonexistent job log by id', () => {
+    app.mockClassFunction('pipelineService', 'getJobById', async (id: string) => {
+      assert.equal(id, 'id');
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .get('/api/job/id/log')
+      .expect(404);
   });
 
   it('should run a job', () => {
@@ -85,6 +225,9 @@ describe('test job controller', () => {
       assert.deepEqual(pipeline, mockPipeline);
       assert.deepEqual(plugins, mockPlugins);
     });
+    app.mockClassFunction('traceManager', 'destroy', async (id, err): Promise<any> => {
+      assert.equal(err, undefined);
+    });
     return app
       .httpRequest()
       .post('/api/job')
@@ -95,6 +238,58 @@ describe('test job controller', () => {
         assert.equal(typeof resp.body.traceId, 'string');
       })
       .expect(200);
+  });
+  it('should run a job with error', () => {
+    app.mockClassFunction('pipelineService', 'getPipeline', async (id: string) => {
+      assert.equal(id, 'id');
+      mockPipeline = { ...mockPipeline, id };
+      return mockPipeline;
+    });
+    app.mockClassFunction('pipelineService', 'fetchPlugins', async (pipeline: any): Promise<any[]> => {
+      assert.deepEqual(pipeline, mockPipeline);
+      return mockPlugins;
+    });
+    app.mockClassFunction('pipelineService', 'createJob', async (pipelineId: string): Promise<any> => {
+      assert.equal(pipelineId, 'id');
+      return mockJob;
+    });
+    const error = new TypeError('mock error');
+    app.mockClassFunction('traceManager', 'create', async (): Promise<any> => {
+      return {
+        id: 'traceId'
+      };
+    });
+    app.mockClassFunction('traceManager', 'destroy', async (id, err): Promise<any> => {
+      assert.equal(id, 'traceId');
+      assert.equal(err, error);
+    });
+    app.mockClassFunction('pipelineService', 'runJob', async (job: any, pipeline: any, plugins: any[], log: any): Promise<any> => {
+      assert.deepEqual(job, mockJob);
+      assert.deepEqual(pipeline, mockPipeline);
+      assert.deepEqual(plugins, mockPlugins);
+      throw error;
+    });
+    return app
+      .httpRequest()
+      .post('/api/job')
+      .send({ pipelineId: 'id' })
+      .expect((resp) => {
+        console.log(resp.body)
+        assert.equal(resp.body.id, mockJob.id);
+        assert.equal(typeof resp.body.traceId, 'string');
+      })
+      .expect(200);
+  });
+  it('should run a job but pipeline not exists', () => {
+    app.mockClassFunction('pipelineService', 'getPipeline', async (id: string): Promise<any> => {
+      assert.equal(id, 'id');
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .post('/api/job')
+      .send({ pipelineId: 'id' })
+      .expect(404);
   });
   it('should download job', () => {
     app.mockClassFunction('pipelineService', 'getJobById', async (id: string) => {

--- a/packages/daemon/test/controller/pipeline.test.ts
+++ b/packages/daemon/test/controller/pipeline.test.ts
@@ -1,7 +1,10 @@
 import { app, assert } from 'midway-mock/bootstrap';
 import { MidwayMockApplication } from 'midway-mock/dist/interface';
 import { PluginPackage } from '@pipcook/costa';
-import { PipelineDB } from '../../src/runner/helper';
+import * as helper from '../../src/runner/helper';
+import * as sinon from 'sinon';
+import { mm } from 'midway-mock/dist/mock';
+import { PluginStatus } from '@pipcook/pipcook-core';
 
 function mockGetPipeline(app: MidwayMockApplication) {
   app.mockClassFunction('pipelineService', 'getPipeline', async (id: string) => {
@@ -24,6 +27,10 @@ function mockGetPipeline(app: MidwayMockApplication) {
 }
 
 describe('test pipeline controller', () => {
+  afterEach(() => {
+    sinon.restore();
+    mm.restore();
+  });
   it('should list all pipelines', () => {
     return app
       .httpRequest()
@@ -31,6 +38,70 @@ describe('test pipeline controller', () => {
       .expect('Content-Type', /json/)
       .expect(200);
   });
+
+  it('should remove all pipelines', () => {
+    const mockJobs = [ { id: '1' }, { id: '2' } ];
+    app.mockClassFunction('pipelineService', 'queryJobs', async () => {
+      return mockJobs;
+    });
+    app.mockClassFunction('pipelineService', 'removeJobByModels', async (jobs: any) => {
+      assert.equal(mockJobs, jobs);
+    });
+    app.mockClassFunction('pipelineService', 'removePipelines', async () => {});
+    return app
+      .httpRequest()
+      .del('/api/pipeline')
+      .expect(204);
+  });
+
+  it('should remove pipeline by id', () => {
+    const mockJobs = [ { id: '1' }, { id: '2' } ];
+    app.mockClassFunction('pipelineService', 'getJobsByPipelineId', async (id: string) => {
+      assert.equal(id, 'id');
+      return mockJobs;
+    });
+    app.mockClassFunction('pipelineService', 'removeJobByModels', async (jobs: any) => {
+      assert.equal(mockJobs, jobs);
+    });
+    app.mockClassFunction('pipelineService', 'removePipelineById', async (id: string) => {
+      assert.equal(id, 'id');
+      return 1;
+    });
+    return app
+      .httpRequest()
+      .del('/api/pipeline/id')
+      .expect(204);
+  });
+
+  it('should remove pipeline by id', () => {
+    const mockJobs = [ { id: '1' }, { id: '2' } ];
+    app.mockClassFunction('pipelineService', 'getJobsByPipelineId', async (id: string) => {
+      assert.equal(id, 'id');
+      return mockJobs;
+    });
+    app.mockClassFunction('pipelineService', 'removeJobByModels', async (jobs: any) => {
+      assert.equal(mockJobs, jobs);
+    });
+    app.mockClassFunction('pipelineService', 'removePipelineById', async (id: string) => {
+      assert.equal(id, 'id');
+      return 0;
+    });
+    return app
+      .httpRequest()
+      .del('/api/pipeline/id')
+      .expect(404);
+  });
+  it('get nonexistent pipeline config', () => {
+    app.mockClassFunction('pipelineService', 'getPipeline', async (id: string): Promise<any> => {
+      assert.equal(id, 'id');
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .get('/api/pipeline/id/config')
+      .expect(404);
+  });
+
   it('should get pipeline config', async () => {
     mockGetPipeline(app);
     return app
@@ -45,6 +116,93 @@ describe('test pipeline controller', () => {
         assert.deepEqual(res.body.plugins.dataAccess.params, { a: 1 });
       });
   });
+
+  it('should update pipeline config', async () => {
+    const mockConfig = {
+      name: 'name',
+      dataCollectId: 'dataCollectId',
+      dataCollect: 'dataCollect',
+      dataCollectParams: '{}',
+      dataAccessId: 'dataAccessId',
+      dataAccess: 'dataAccess',
+      dataAccessParams: '{"a":1}'
+    };
+    const mockParseConfig = sinon.stub(helper, 'parseConfig').resolves(mockConfig);
+    app.mockClassFunction('pipelineService', 'updatePipelineById', async (id: string, config: any): Promise<any> => {
+      assert.equal(id, 'id');
+      assert.equal(mockConfig, config);
+      return config;
+    });
+    const sendConfig = {
+      name: 'name',
+      config: {
+        plugins: {
+          dataCollect: {
+            package: 'dataCollect',
+            params: { testParam: '123' }
+          },
+          dataAccess: {
+            package: 'dataAccess',
+            params: { testParam: '456' }
+          },
+        }
+      }
+    };
+    return app
+      .httpRequest()
+      .put('/api/pipeline/id').send(sendConfig)
+      .expect('Content-Type', /json/)
+      .expect(200).then((res) => {
+        console.log(res.body);
+        assert.ok(mockParseConfig.calledOnce);
+        assert.equal(res.body.name, 'name');
+        assert.equal(res.body.dataCollect, 'dataCollect');
+        assert.deepEqual(res.body.dataCollectParams, '{}');
+        assert.equal(res.body.dataAccess, 'dataAccess');
+        assert.deepEqual(res.body.dataAccessParams, '{"a":1}');
+      });
+  });
+
+  it('update nonexistent pipeline', async () => {
+    const mockConfig = {
+      name: 'name',
+      dataCollectId: 'dataCollectId',
+      dataCollect: 'dataCollect',
+      dataCollectParams: '{}',
+      dataAccessId: 'dataAccessId',
+      dataAccess: 'dataAccess',
+      dataAccessParams: '{"a":1}'
+    };
+    const mockParseConfig = sinon.stub(helper, 'parseConfig').resolves(mockConfig);
+    app.mockClassFunction('pipelineService', 'updatePipelineById', async (id: string, config: any): Promise<any> => {
+      assert.equal(id, 'id');
+      assert.equal(mockConfig, config);
+      return undefined;
+    });
+    const sendConfig = {
+      name: 'name',
+      config: {
+        plugins: {
+          dataCollect: {
+            package: 'dataCollect',
+            params: { testParam: '123' }
+          },
+          dataAccess: {
+            package: 'dataAccess',
+            params: { testParam: '456' }
+          },
+        }
+      }
+    };
+    return app
+      .httpRequest()
+      .put('/api/pipeline/id').send(sendConfig)
+      .expect('Content-Type', /json/)
+      .expect(404).expect(()=> {
+        assert.ok(mockParseConfig.calledOnce);
+      });
+  });
+
   it('should get pipeline info', async () => {
     mockGetPipeline(app);
     app.mockClassFunction('pluginManager', 'findByIds', async (ids: string[]) => {
@@ -78,6 +236,17 @@ describe('test pipeline controller', () => {
         ]);
       });
   });
+  it('get nonexsitent pipeline info', async () => {
+    app.mockClassFunction('pipelineService', 'getPipeline', async (id: string): Promise<any> => {
+      assert.equal(id, 'id');
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .get('/api/pipeline/id')
+      .expect('Content-Type', /json/)
+      .expect(404);
+  });
   it('should create pipeline', async () => {
     app.mockClassFunction('pluginManager', 'fetch', async (name: string) => {
       if (name) {
@@ -107,7 +276,7 @@ describe('test pipeline controller', () => {
         };
       }
     });
-    app.mockClassFunction('pipelineService', 'createPipeline', async (pipeline: PipelineDB) => {
+    app.mockClassFunction('pipelineService', 'createPipeline', async (pipeline: helper.PipelineDB) => {
       assert.equal(pipeline.name, 'name');
       assert.equal(pipeline.dataCollectId, 'dataCollectInstalled');
       assert.equal(pipeline.dataCollect, 'dataCollect');
@@ -152,6 +321,116 @@ describe('test pipeline controller', () => {
           {id: 'dataCollectInstalled', name: 'dataCollect', status: 1},
           {id: 'dataAccessId', name: 'dataAccess'}
         ]);
+      });
+  });
+  it('install nonexistent pipeline', async () => {
+    app.mockClassFunction('pipelineService', 'getPipeline', async (id: string): Promise<any> => {
+      assert.equal(id, 'id');
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .post('/api/pipeline/id/installation')
+      .expect('Content-Type', /json/)
+      .expect(404);
+  });
+  const installPipeline = (isError: boolean) => {
+    const mockPkg = {
+      name: 'dataCollect',
+      version: '1.0.0'  
+    }
+    const mockPlugin = {
+      id: 'id',
+      name: 'name',
+      dataCollectId: 'dataCollectId',
+      dataCollect: 'dataCollect',
+      dataCollectParams: '{}',
+      dataAccessId: 'dataAccessId',
+      dataAccess: 'dataAccess',
+      dataAccessParams: '{"a":1}',
+      toJSON: function () {
+        return this;  
+      }
+    };
+    app.mockClassFunction('pluginManager', 'findByName', async (name: string): Promise<any> => {
+      assert.ok([ 'dataAccess', 'dataCollect' ].indexOf(name) != -1);
+      if (name === 'dataAccess') {
+        return {
+          name: 'dataAccess',
+          version: '1.0.0',
+          status: PluginStatus.INSTALLED
+        };
+      } else {
+        return {
+          name: 'dataCollect',
+          version: '1.0.1',
+          status: PluginStatus.FAILED
+        };
+      }
+    });
+    app.mockClassFunction('pluginManager', 'fetch', async (name: string): Promise<any> => {
+      assert.equal(name, mockPkg.name);
+      return mockPkg;
+    });
+    app.mockClassFunction('pluginManager', 'findOrCreateByPkg', async (pkg: any): Promise<any> => {
+      assert.deepEqual(pkg, mockPkg);
+      return mockPlugin;
+    });
+    app.mockClassFunction('pluginManager', 'install', async (id: string, pkg: any, opts: any): Promise<any> => {
+      assert.deepEqual(id, 'id');
+      assert.deepEqual(pkg, mockPkg);
+      if (isError) {
+        throw new TypeError('mock error');
+      }
+    });
+    app.mockClassFunction('pluginManager', 'setStatusById', async (id: string, status: PluginStatus, error: string): Promise<any> => {
+      assert.deepEqual(id, 'id');
+      if (status === PluginStatus.INSTALLED) {
+        assert.equal(error, undefined);
+      } else {
+        assert.equal(error, 'mock error');
+      }
+    });
+    mockGetPipeline(app);
+    app.mockClassFunction('traceManager', 'destroy', async (id: string, err: Error): Promise<any> => {
+      if (isError) {
+        assert.equal(err.message, 'mock error');
+      } else {
+        assert.equal(err, undefined);
+      }
+    });
+    return app
+      .httpRequest()
+      .post('/api/pipeline/id/installation')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  };
+  it('should install pipeline', async () => {
+    return installPipeline(false);
+  });
+  it('should install pipeline with error', async () => {
+    return installPipeline(true);
+  });
+  it('should trace event', () => {
+    app.mockClassFunction('traceManager', 'get', (id: string): any => {
+      assert.equal(id, 'trace-id');
+      let callback: Function;
+      return {
+        listen: (cb) => {
+          callback = cb;
+        },
+        wait: async () => {
+          return callback({ type: 'mock type', data: 'mock data' });
+        }
+      }
+    });
+    return app
+      .httpRequest()
+      .get('/api/pipeline/event/trace-id')
+      .expect(200).expect((res) => {
+        console.log('trace res', res.text);
+        assert.ok((res.text as string).indexOf('mock type') >= 0);
+        assert.ok((res.text as string).indexOf('mock data') >= 0);
       });
   });
 });


### PR DESCRIPTION
Improve `Job` and `Pipeline` controllers coverage to  [ 100%, 100% ] from [ 67.69%, 57.69%].