### PR TITLE
daemon: add test for controllers

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -35,6 +35,7 @@
     "@types/request-promise": "^4.1.46",
     "cross-env": "^6.0.0",
     "egg-ci": "^1.8.0",
+    "form-data": "^3.0.0",
     "midway-bin": "1",
     "midway-mock": "1",
     "sinon": "^9.0.3",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -35,7 +35,6 @@
     "@types/request-promise": "^4.1.46",
     "cross-env": "^6.0.0",
     "egg-ci": "^1.8.0",
-    "form-data": "^3.0.0",
     "midway-bin": "1",
     "midway-mock": "1",
     "sinon": "^9.0.3",

--- a/packages/daemon/src/app/controller/plugin.ts
+++ b/packages/daemon/src/app/controller/plugin.ts
@@ -29,7 +29,7 @@ export class PluginController extends BaseEventController {
    */
   @put()
   public async reinstall() {
-    const { name, pyIndex } = this.ctx.query;
+    const { name, pyIndex } = this.ctx.request.body;
     debug(`checking info: ${name}.`);
     const response = await this.pluginManager.installByName(name, pyIndex, true);
     this.ctx.success(response);
@@ -40,16 +40,12 @@ export class PluginController extends BaseEventController {
    */
   @del('/:id')
   public async remove() {
-    if (typeof this.ctx.params.id === 'string' && this.ctx.params.id) {
-      const plugin = await this.pluginManager.findById(this.ctx.params.id);
-      if (plugin) {
-        await this.pluginManager.uninstall(plugin);
-        this.ctx.success();
-      } else {
-        this.ctx.throw(HttpStatus.NOT_FOUND, `no plugin found by id ${this.ctx.params.id}`);
-      }
+    const plugin = await this.pluginManager.findById(this.ctx.params.id);
+    if (plugin) {
+      await this.pluginManager.uninstall(plugin);
+      this.ctx.success();
     } else {
-      this.ctx.throw(HttpStatus.BAD_REQUEST, 'no id value found');
+      this.ctx.throw(HttpStatus.NOT_FOUND, `no plugin found by id ${this.ctx.params.id}`);
     }
   }
 
@@ -121,6 +117,7 @@ export class PluginController extends BaseEventController {
   @post('/tarball')
   public async uploadPackage() {
     const fstream = await this.ctx.getFileStream();
+    console.log('fstream.fields', fstream.fields);
     const { pyIndex } = fstream.fields;
     const installResp = await this.pluginManager.installFromTarStream(fstream, pyIndex, false);
     this.ctx.success(installResp);

--- a/packages/daemon/src/app/controller/plugin.ts
+++ b/packages/daemon/src/app/controller/plugin.ts
@@ -117,7 +117,6 @@ export class PluginController extends BaseEventController {
   @post('/tarball')
   public async uploadPackage() {
     const fstream = await this.ctx.getFileStream();
-    console.log('fstream.fields', fstream.fields);
     const { pyIndex } = fstream.fields;
     const installResp = await this.pluginManager.installFromTarStream(fstream, pyIndex, false);
     this.ctx.success(installResp);

--- a/packages/daemon/test/controller/app.test.ts
+++ b/packages/daemon/test/controller/app.test.ts
@@ -1,0 +1,26 @@
+import { app, assert, mm } from 'midway-mock/bootstrap';
+
+describe('test app controller', () => {
+  afterEach(() => {
+    mm.restore();
+  });
+  it('should compile app', () => {
+    app.mockClassFunction('AppService', 'compile', async (src: string) => {
+      assert.equal(src, 'source');
+      return {
+        executableSource: 'executableSource',
+        pipelines: 'pipelines'
+      };
+    });
+    return app
+      .httpRequest()
+      .post('/app/compile')
+      .send({ src: 'source' })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect((res) => {
+        assert.equal(res.body.executableSource, 'executableSource');
+        assert.equal(res.body.pipelines, 'pipelines');
+      });
+  });
+});

--- a/packages/daemon/test/controller/base.test.ts
+++ b/packages/daemon/test/controller/base.test.ts
@@ -1,0 +1,20 @@
+import { app } from 'midway-mock/bootstrap';
+
+
+describe('test base controller', () => {
+  it('validate failed', () => {
+    return app
+      .httpRequest()
+      .post('/api/pipeline')
+      .send({ a: 1 })
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
+  it('tracer not found', () => {
+    return app
+      .httpRequest()
+      .get('/api/pipeline/event/id')
+      .expect('Content-Type', /text/)
+      .expect(200);
+  });
+});

--- a/packages/daemon/test/controller/base.test.ts
+++ b/packages/daemon/test/controller/base.test.ts
@@ -1,4 +1,4 @@
-import { app } from 'midway-mock/bootstrap';
+import { app, assert } from 'midway-mock/bootstrap';
 
 
 describe('test base controller', () => {
@@ -16,5 +16,15 @@ describe('test base controller', () => {
       .get('/api/pipeline/event/id')
       .expect('Content-Type', /text/)
       .expect(200);
+  });
+  it('throw 500', () => {
+    app.mockClassFunction('pipelineService', 'stopJob', async (id: string) => {
+      assert.equal(id, 'id');
+      throw new TypeError('mock error');
+    });
+    return app
+      .httpRequest()
+      .post('/api/job/id/cancel')
+      .expect(500);
   });
 });

--- a/packages/daemon/test/controller/job.test.ts
+++ b/packages/daemon/test/controller/job.test.ts
@@ -161,17 +161,6 @@ describe('test job controller', () => {
       .expect(204);
   });
 
-  it('cancel job with error', () => {
-    app.mockClassFunction('pipelineService', 'stopJob', async (id: string) => {
-      assert.equal(id, 'id');
-      throw new TypeError('mock error');
-    });
-    return app
-      .httpRequest()
-      .post('/api/job/id/cancel')
-      .expect(500);
-  });
-
   it('should get job log by id', () => {
     const logs = [
       '1', 

--- a/packages/daemon/test/controller/log.test.ts
+++ b/packages/daemon/test/controller/log.test.ts
@@ -1,0 +1,25 @@
+import { app, assert, mm } from 'midway-mock/bootstrap';
+
+describe('test log controller', () => {
+  afterEach(() => {
+    mm.restore();
+  });
+  it('should get log', () => {
+    app.mockClassFunction('pipelineService', 'getLogById', async (id: string) => {
+      assert.equal(id, 'id');
+      return [
+        'log1',
+        'log2'
+      ];
+    });
+    return app
+      .httpRequest()
+      .get('/log/view/id')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect((res) => {
+        assert.equal(res.body[0], 'log1');
+        assert.equal(res.body[1], 'log2');
+      });
+  });
+});

--- a/packages/daemon/test/controller/playground.test.ts
+++ b/packages/daemon/test/controller/playground.test.ts
@@ -1,0 +1,26 @@
+import { app, assert } from 'midway-mock/bootstrap';
+import { mm } from 'midway-mock/dist/mock';
+import * as sinon from 'sinon';
+import axios from 'axios';
+import * as fs from 'fs-extra';
+
+describe('test playground controller', () => {
+  afterEach(() => {
+    mm.restore();
+    sinon.restore();
+  });
+  it('should get model', () => {
+    const mockGet = sinon.stub(axios, 'get').resolves(fs.createReadStream(`${__dirname}/playground.test.ts`) as any);
+    return app
+      .httpRequest()
+      .get('/playground/model/model/name')
+      .expect(204).expect(res => {
+        assert.ok(
+          mockGet.calledOnceWithExactly(
+            'http://ai-sample.oss-cn-hangzhou.aliyuncs.com/pipcook/showcase/model/name',
+            { responseType: 'stream' }
+          )
+        );
+      });
+  });
+});

--- a/packages/daemon/test/controller/plugin.test.ts
+++ b/packages/daemon/test/controller/plugin.test.ts
@@ -1,8 +1,6 @@
 import { app, assert } from 'midway-mock/bootstrap';
 import { mm } from 'midway-mock/dist/mock';
 import * as fs from 'fs-extra';
-import * as FormData from 'form-data';
-import { promisify } from 'util';
 
 describe('test plugin controller', () => {
   const name = '@pipcook/plugins-image-classification-data-collect';
@@ -93,13 +91,16 @@ describe('test plugin controller', () => {
   });
 
   it('should upload plugin', async () => {
-    const form = new FormData();
-    form.append('file', fs.createReadStream(`${__dirname}/../../../../logo.png`));
-    const getLength = promisify(form.getLength.bind(form));
-    const length = await getLength();
-    const headers = Object.assign({ 'Content-Length': length }, form.getHeaders());
-    
-    app.mockClassFunction('pluginManager', 'installFromTarStream', async (tarball: NodeJS.ReadableStream, pyIndex?: string, force?: boolean): Promise<any> => {
+    // const form = new FormData();
+    // form.append('file', fs.createReadStream(`${__dirname}/../../../../logo.png`));
+    // const getLength = promisify(form.getLength.bind(form));
+    // const length = await getLength();
+    // const headers = Object.assign({ 'Content-Length': length }, form.getHeaders());
+
+    app.mockClassFunction(
+      'pluginManager',
+      'installFromTarStream',
+      async (tarball: NodeJS.ReadableStream, pyIndex?: string, force?: boolean): Promise<any> => {
       assert.equal(pyIndex, 'pyindex.com');
       assert.equal(force, false);
       return undefined;
@@ -107,11 +108,9 @@ describe('test plugin controller', () => {
     return app
       .httpRequest()
       .post('/api/plugin/tarball')
-      .set(headers)
-      .field({
-        file: fs.createReadStream(`${__dirname}/../../../../logo.png`),
-        pyIndex: 'pyindex.com'
-      })
+      // .set(headers)
+      .field('pyIndex', 'pyindex.com')
+      .attach('file', fs.createReadStream(`${__dirname}/../../../../logo.png`))
       .expect(204);
   });
 

--- a/packages/daemon/test/controller/plugin.test.ts
+++ b/packages/daemon/test/controller/plugin.test.ts
@@ -1,8 +1,14 @@
 import { app, assert } from 'midway-mock/bootstrap';
+import { mm } from 'midway-mock/dist/mock';
+import * as fs from 'fs-extra';
+import * as FormData from 'form-data';
+import { promisify } from 'util';
 
 describe('test plugin controller', () => {
   const name = '@pipcook/plugins-image-classification-data-collect';
-
+  afterEach(() => {
+    mm.restore();
+  })
   it('should list plugins', () => {
     return app
       .httpRequest()
@@ -35,6 +41,28 @@ describe('test plugin controller', () => {
       .expect(200);
   });
 
+  it('should reinstall a plugin', () => {
+    app.mockClassFunction('pluginManager', 'installByName', async (pkgName: string, pyIndex?: string, force?: boolean) => {
+      assert.equal(pkgName, name);
+      assert.equal(pyIndex, 'http://pyindex.com');
+      assert.equal(force, true);
+      return {
+        id: '123',
+        name
+      };
+    });
+    return app
+      .httpRequest()
+      .put('/api/plugin')
+      .send({ name, pyIndex: 'http://pyindex.com' })
+      .expect((resp) => {
+        console.log(resp.body);
+        assert.equal(typeof resp.body.id, 'string');
+        assert.equal(resp.body.name, name);
+      })
+      .expect(200);
+  });
+
   it('should get the plugin', () => {
     app.mockClassFunction('pluginManager', 'findById', async (id: string) => {
       assert.equal(id, 'id');
@@ -51,6 +79,82 @@ describe('test plugin controller', () => {
         assert.equal(resp.body.name, name);
       })
       .expect(200);
+  });
+
+  it('try to get a nonexistent plugin', () => {
+    app.mockClassFunction('pluginManager', 'findById', async (id: string): Promise<any> => {
+      assert.equal(id, 'id');
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .get('/api/plugin/id')
+      .expect(404);
+  });
+
+  it('should upload plugin', async () => {
+    const form = new FormData();
+    form.append('file', fs.createReadStream(`${__dirname}/../../../../logo.png`));
+    const getLength = promisify(form.getLength.bind(form));
+    const length = await getLength();
+    const headers = Object.assign({ 'Content-Length': length }, form.getHeaders());
+    
+    app.mockClassFunction('pluginManager', 'installFromTarStream', async (tarball: NodeJS.ReadableStream, pyIndex?: string, force?: boolean): Promise<any> => {
+      assert.equal(pyIndex, 'pyindex.com');
+      assert.equal(force, false);
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .post('/api/plugin/tarball')
+      .set(headers)
+      .field({
+        file: fs.createReadStream(`${__dirname}/../../../../logo.png`),
+        pyIndex: 'pyindex.com'
+      })
+      .expect(204);
+  });
+
+  it('should remove the plugin by id', () => {
+    const mockPlugin = {
+      id: 'id',
+      name
+    }
+    app.mockClassFunction('pluginManager', 'findById', async (id: string) => {
+      assert.equal(id, 'id');
+      return mockPlugin;
+    });
+    app.mockClassFunction('pluginManager', 'uninstall', async (plugin: any) => {
+      assert.deepEqual(plugin, mockPlugin);
+    });
+    return app
+      .httpRequest()
+      .del('/api/plugin/id')
+      .expect(204);
+  });
+
+  it('remove nonexistent plugin', () => {
+    app.mockClassFunction('pluginManager', 'findById', async (id: string): Promise<any> => {
+      assert.equal(id, 'id');
+      return undefined;
+    });
+    return app
+      .httpRequest()
+      .del('/api/plugin/id')
+      .expect(404);
+  });
+
+  it('remove all plugins', () => {
+    app.mockClassFunction('pluginManager', 'list', async (): Promise<any> => {
+      return [];
+    });
+    app.mockClassFunction('pluginManager', 'uninstall', async (plugins: any[]): Promise<any> => {
+      assert.deepEqual(plugins, []);
+    });
+    return app
+      .httpRequest()
+      .del('/api/plugin')
+      .expect(204);
   });
 
   it('should get the plugin metadata', () => {
@@ -114,5 +218,27 @@ describe('test plugin controller', () => {
       .httpRequest()
       .get('/api/plugin/metadata')
       .expect(400);
+  });
+  it('should trace event', () => {
+    app.mockClassFunction('traceManager', 'get', (id): any => {
+      assert.equal(id, 'trace-id');
+      let callback;
+      return {
+        listen: (cb) => {
+          callback = cb;
+        },
+        wait: async () => {
+          return callback({ type: 'mock type', data: 'mock data' });
+        }
+      }
+    });
+    return app
+      .httpRequest()
+      .get('/api/plugin/event/trace-id')
+      .expect(200).expect((res) => {
+        console.log('trace res', res.text);
+        assert.ok((res.text as string).indexOf('mock type') >= 0);
+        assert.ok((res.text as string).indexOf('mock data') >= 0);
+      });
   });
 });


### PR DESCRIPTION
Improve `App`, `Base`, `Log`, `Playground`, `Plugin` controllers coverage:

![image](https://user-images.githubusercontent.com/10196611/92511079-6afc4300-f23f-11ea-92ec-e38024dc5f94.png)
