### PR TITLE
costa: send signal instead of ipc to destroy client

### DIFF
--- a/packages/costa/src/client/entry.ts
+++ b/packages/costa/src/client/entry.ts
@@ -135,6 +135,15 @@ async function emitStart(message: PluginMessage): Promise<void> {
 }
 
 /**
+ * Emits a destroy event, it exits the current client process.
+ */
+async function emitDestroy(): Promise<void> {
+  clientId = null;
+  handshaked = false;
+  process.exit(0);
+}
+
+/**
  * Gets the response by a result.
  * @param message
  */
@@ -170,6 +179,8 @@ const handlers: MessageHandler = {
     debug(`receive an event write.${event}`);
     if (event === 'start') {
       emitStart(proto.message);
+    } else if (event === 'destroy') {
+      emitDestroy();
     }
   },
   /**

--- a/packages/costa/src/client/entry.ts
+++ b/packages/costa/src/client/entry.ts
@@ -135,15 +135,6 @@ async function emitStart(message: PluginMessage): Promise<void> {
 }
 
 /**
- * Emits a destroy event, it exits the current client process.
- */
-async function emitDestroy(): Promise<void> {
-  clientId = null;
-  handshaked = false;
-  process.exit(0);
-}
-
-/**
  * Gets the response by a result.
  * @param message
  */
@@ -179,8 +170,6 @@ const handlers: MessageHandler = {
     debug(`receive an event write.${event}`);
     if (event === 'start') {
       emitStart(proto.message);
-    } else if (event === 'destroy') {
-      emitDestroy();
     }
   },
   /**

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -161,7 +161,6 @@ export class PluginRunnable {
     });
     this.state = 'idle';
 
-    console.log('resp', resp);
     // return if the result id is provided.
     const id = resp.params[0];
     if (id === 'error') {

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -161,6 +161,7 @@ export class PluginRunnable {
     });
     this.state = 'idle';
 
+    console.log('resp', resp);
     // return if the result id is provided.
     const id = resp.params[0];
     if (id === 'error') {

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -19,7 +19,7 @@ export class RunnableResponse implements PluginResponse {
 }
 
 // wait 5000ms for chile process finish.
-const waitForEnd = 5000;
+const waitForDestroied = 5000;
 /**
  * The arguments for calling `bootstrap`.
  */
@@ -179,9 +179,10 @@ export class PluginRunnable {
       return;
     }
     this.canceled = true;
+    // if not exit after `waitForEnd`, we need to kill it directly.
     this.termTimer = setTimeout(() => {
-      this.handle.kill('SIGKILL');  
-    }, waitForEnd);
+      this.handle.kill('SIGKILL');
+    }, waitForDestroied);
     this.handle.kill('SIGTERM');
     return new Promise((resolve) => {
       this.ondestroyed = resolve;

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -179,11 +179,11 @@ export class PluginRunnable {
       return;
     }
     this.canceled = true;
-    // if not exit after `waitForEnd`, we need to kill it directly.
+    // if not exit after `waitForDestroied`, we need to kill it directly.
     this.termTimer = setTimeout(() => {
       this.handle.kill('SIGKILL');
     }, waitForDestroied);
-    this.handle.kill('SIGTERM');
+    this.send(PluginOperator.WRITE, { event: 'destroy' });
     return new Promise((resolve) => {
       this.ondestroyed = resolve;
     });
@@ -244,6 +244,7 @@ export class PluginRunnable {
     }
     return resp;
   }
+
   /**
    * handle the messages from peer client.
    * @param msg

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -18,8 +18,8 @@ export class RunnableResponse implements PluginResponse {
   }
 }
 
-// wait 5000ms for chile process finish.
-const waitForDestroied = 5000;
+// wait 1000ms for chile process finish.
+const waitForDestroied = 1000;
 /**
  * The arguments for calling `bootstrap`.
  */

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -18,6 +18,8 @@ export class RunnableResponse implements PluginResponse {
   }
 }
 
+// wait 5000ms for chile process finish.
+const waitForEnd = 5000;
 /**
  * The arguments for calling `bootstrap`.
  */
@@ -47,7 +49,8 @@ export class PluginRunnable {
   private onread: Function | null;
   private onreadfail: Function | null;
   private ondestroyed: Function | null;
-
+  // timer for wait the process to exit itself
+  private termTimer: NodeJS.Timeout;
   /**
    * The runnable id.
    */
@@ -176,7 +179,10 @@ export class PluginRunnable {
       return;
     }
     this.canceled = true;
-    this.handle.kill('SIGHUP');
+    this.termTimer = setTimeout(() => {
+      this.handle.kill('SIGKILL');  
+    }, waitForEnd);
+    this.handle.kill('SIGTERM');
     return new Promise((resolve) => {
       this.ondestroyed = resolve;
     });
@@ -252,6 +258,9 @@ export class PluginRunnable {
    */
   private async afterDestroy(code: number, signal: NodeJS.Signals): Promise<void> {
     debug(`the runnable(${this.id}) has been destroyed with(code=${code}, signal=${signal}).`);
+    if (this.termTimer) {
+      clearTimeout(this.termTimer);
+    }
     // FIXME(Yorkie): remove component directory?
     // await remove(path.join(this.rt.options.componentDir, this.id));
     if (typeof this.onread === 'function' && typeof this.onreadfail === 'function') {

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -176,7 +176,7 @@ export class PluginRunnable {
       return;
     }
     this.canceled = true;
-    this.send(PluginOperator.WRITE, { event: 'destroy' });
+    this.handle.kill('SIGHUP');
     return new Promise((resolve) => {
       this.ondestroyed = resolve;
     });

--- a/packages/costa/test/plugins/nodejs-simple/index.js
+++ b/packages/costa/test/plugins/nodejs-simple/index.js
@@ -1,6 +1,16 @@
 
 module.exports = function(data) {
   console.log(data);
+  if (data && data.exitAfter && typeof data.exitAfter === 'number') {
+    const start = Date.now();
+    console.log('loop in');
+    while (true) {
+      if (Date.now() - start > data.exitAfter * 1000) {
+        break;
+      }
+    }
+    console.log('loop out');
+  }
   return {
     foobar: data.foobar,
     fn1: (a) => console.log(`fn1(${a})`),

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -122,10 +122,9 @@ describe('start runnable in normal way', () => {
       runnable.destroy();
     }, 1000);
     const start = Date.now();
-    try {
+    expect(async () => {
       await runnable.start(simple, { foobar: true, exitAfter: 5 });
-    } catch (err) {
-    }
+    }).toThrowError(TypeError);
     expect(Date.now() - start < 5000);
   });
 });

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -101,7 +101,7 @@ describe('start runnable in normal way', () => {
     // test if the plugin is executed successfully
     await runnable.start(simple, tmp);
     const stdout = logger.stdout.data;
-    expect(stdout.indexOf('hello python!') !== 0).toBe(true);
+    expect(stdout.indexOf('hello python!') >= 0).toBe(true);
   });
 
   it('should destroy the runnable', async () => {

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -122,9 +122,7 @@ describe('start runnable in normal way', () => {
       runnable.destroy();
     }, 1000);
     const start = Date.now();
-    expect(async () => {
-      await runnable.start(simple, { foobar: true, exitAfter: 5 });
-    }).toThrowError(Error);
+    await runnable.start(simple, { foobar: true, exitAfter: 5 });
     expect(Date.now() - start < 5000);
   });
 });

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -122,13 +122,9 @@ describe('start runnable in normal way', () => {
       runnable.destroy();
     }, 1000);
     const start = Date.now();
-    console.log(start);
-    try {
-      await runnable.start(simple, { foobar: true, exitAfter: 5 });
-    } catch (err) {
-      console.log(err);
-    }
-    console.log(Date.now());
+    expect(() => {
+      runnable.start(simple, { foobar: true, exitAfter: 5 });
+    }).toThrowError();
     expect(Date.now() - start < 5000);
   });
 });

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -124,7 +124,7 @@ describe('start runnable in normal way', () => {
     const start = Date.now();
     expect(async () => {
       await runnable.start(simple, { foobar: true, exitAfter: 5 });
-    }).toThrowError(TypeError);
+    }).toThrowError(Error);
     expect(Date.now() - start < 5000);
   });
 });

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -122,7 +122,9 @@ describe('start runnable in normal way', () => {
       runnable.destroy();
     }, 1000);
     const start = Date.now();
-    await runnable.start(simple, { foobar: true, exitAfter: 5 });
+    expect(async () => {
+      await runnable.start(simple, { foobar: true, exitAfter: 5 });
+    }).toThrowError();
     expect(Date.now() - start < 5000);
   });
 });

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -110,4 +110,22 @@ describe('start runnable in normal way', () => {
     const list = await readdir(costa.options.componentDir);
     expect(list.length).toBe(1);
   });
+
+  it('should start a nodejs plugin and loop 5 seconds', async () => {
+    runnable = new PluginRunnable(costa);
+    await runnable.bootstrap({});
+    const stdoutStream = new StringWritable();
+    const stderrStream = new StringWritable();
+    const simple = await costa.fetch(path.join(__dirname, '../../test/plugins/nodejs-simple'));
+    await costa.install(simple, { stdout: stdoutStream, stderr: stderrStream});
+    setTimeout(() => {
+      runnable.destroy();
+    }, 1000);
+    const start = Date.now();
+    try {
+      await runnable.start(simple, { foobar: true, exitAfter: 5 });
+    } catch (err) {
+    }
+    expect(Date.now() - start < 5000);
+  });
 });

--- a/packages/costa/test/runnable_test.ts
+++ b/packages/costa/test/runnable_test.ts
@@ -122,9 +122,13 @@ describe('start runnable in normal way', () => {
       runnable.destroy();
     }, 1000);
     const start = Date.now();
-    expect(async () => {
+    console.log(start);
+    try {
       await runnable.start(simple, { foobar: true, exitAfter: 5 });
-    }).toThrowError();
+    } catch (err) {
+      console.log(err);
+    }
+    console.log(Date.now());
     expect(Date.now() - start < 5000);
   });
 });


### PR DESCRIPTION
Fix #561 .
Costa sends the destroy-request by IPC, if the client is busy, i.e. training loop in boa stack, the request will not be processed util the `nextTick`, so it will not exit immediately. But we can use signal to make sure the client process can receive it when the OS switches the process from sleeping to running.