### PR TITLE
ci: delete daily run of NER pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         node_version: ['12']
         os: [ubuntu-latest]
-        pipeline: ['mnist-image-classification', 'databinding-image-classification-resnet', 'text-bayes-classification', 'fasttext', 'english-name-entity-recognition']
+        pipeline: ['mnist-image-classification', 'databinding-image-classification-resnet', 'text-bayes-classification', 'fasttext']
     steps:
     - uses: actions/checkout@v2
     - name: Using Node.js ${{ matrix.node_version }}


### PR DESCRIPTION
Currently, the CI machine to run pipeline only has 4G memory. This is not enough for BERT model. This PR is to stop this pipeline's daily run temporarily. For the future, we need to transfer our pipeline run to our own machine or to other CI services