### PR TITLE
pipeline, daemon: split data dir for data-collect and data-access

### DIFF
--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -99,8 +99,7 @@ export class PluginRunnable {
     const compPath = this.workingDir;
 
     debug(`make sure the component dir is existed.`);
-    await ensureDir(compPath + '/node_modules');
-    await ensureDir(this.dataDir);
+    await Promise.all([ ensureDir(compPath + '/node_modules'), ensureDir(this.dataDir) ]);
 
     debug(`bootstrap a new process for ${this.id}.`);
     this.handle = fork(__dirname + '/client/entry', [], {

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -62,6 +62,11 @@ export class PluginRunnable {
   public workingDir: string;
 
   /**
+   * the current data directory for this runnable
+   */
+  public dataDir: string;
+
+  /**
    * The current state.
    */
   public state: 'init' | 'idle' | 'busy';
@@ -83,6 +88,7 @@ export class PluginRunnable {
     this.id = id || generateId();
     this.rt = rt;
     this.workingDir = path.join(this.rt.options.componentDir, this.id);
+    this.dataDir = path.join(this.workingDir, 'data');
     this.state = 'init';
     this.logger = logger || process;
   }
@@ -94,6 +100,7 @@ export class PluginRunnable {
 
     debug(`make sure the component dir is existed.`);
     await ensureDir(compPath + '/node_modules');
+    await ensureDir(this.dataDir);
 
     debug(`bootstrap a new process for ${this.id}.`);
     this.handle = fork(__dirname + '/client/entry', [], {

--- a/packages/daemon/src/runner/job-runner.ts
+++ b/packages/daemon/src/runner/job-runner.ts
@@ -244,7 +244,11 @@ export class JobRunner {
     const modelPath = path.join(this.opts.runnable.workingDir, 'model');
 
     await this.runDataCollect(dataDir, modelPath);
-    const dataset = await this.runDataAccess(dataDir);
+
+    // move plugin data directory data to job's data directory
+    await fs.copy(dataDir, this.opts.runnable.dataDir);
+
+    const dataset = await this.runDataAccess(this.opts.runnable.dataDir);
     await this.runDatasetProcess(dataset);
     await this.runDataProcess(dataset);
 

--- a/packages/daemon/src/runner/job-runner.ts
+++ b/packages/daemon/src/runner/job-runner.ts
@@ -8,6 +8,7 @@ import { PluginPackage, RunnableResponse, PluginRunnable } from '@pipcook/costa'
 import { PipelineEntity } from '../model/pipeline';
 import { JobParam, JobEntity } from '../model/job';
 import { Tracer, JobStatusChangeEvent } from '../service/trace-manager';
+import { copyDir } from '../utils';
 
 /**
  * plugin info from pipeline config
@@ -246,7 +247,7 @@ export class JobRunner {
     await this.runDataCollect(dataDir, modelPath);
 
     // move plugin data directory data to job's data directory
-    await fs.copy(dataDir, this.opts.runnable.dataDir);
+    await copyDir(dataDir, this.opts.runnable.dataDir);
 
     const dataset = await this.runDataAccess(this.opts.runnable.dataDir);
     await this.runDatasetProcess(dataset);

--- a/packages/daemon/src/utils.ts
+++ b/packages/daemon/src/utils.ts
@@ -124,7 +124,7 @@ export async function copyDir(src: string, dest: string): Promise<void> {
     srcStat.isBlockDevice()
   ) {
     await onFile(src, dest, srcStat.mode);
-  } else if (srcStat.isSymbolicLink) {
+  } else if (srcStat.isSymbolicLink()) {
     await onLink(src, dest);
   }
 }

--- a/packages/daemon/src/utils.ts
+++ b/packages/daemon/src/utils.ts
@@ -93,3 +93,38 @@ export async function parseConfig(configPath: string | RunConfigI, isGenerateId 
     modelEvaluateParams: parseParams(configJson.plugins.modelEvaluate?.params)
   };
 }
+
+/**
+ * copy the folder with reflink mode
+ */
+export async function copyDir(src: string, dest: string): Promise<void> {
+  const onDir = async (src: string, dest: string) => {
+    await fs.ensureDir(dest);
+    const items = await fs.readdir(src);
+    const copyPromises = items.map(item => copyDir(path.join(src, item), path.join(dest, item)));
+    return Promise.all(copyPromises);
+  };
+
+  const onFile = async (src: string, dest: string, mode: number) => {
+    await fs.copyFile(src, dest, fs.constants.COPYFILE_FICLONE);
+    await fs.chmod(dest, mode);
+  };
+
+  const onLink = async (src: string, dest: string) => {
+    const resolvedSrc = await fs.readlink(src);
+    await fs.symlink(resolvedSrc, dest);
+  };
+
+  const srcStat = await fs.lstat(src);
+  if (srcStat.isDirectory()) {
+    await onDir(src, dest);
+  } else if (
+    srcStat.isFile() ||
+    srcStat.isCharacterDevice() ||
+    srcStat.isBlockDevice()
+  ) {
+    await onFile(src, dest, srcStat.mode);
+  } else if (srcStat.isSymbolicLink) {
+    await onLink(src, dest);
+  }
+}

--- a/packages/daemon/test/runner/helper.test.ts
+++ b/packages/daemon/test/runner/helper.test.ts
@@ -146,6 +146,6 @@ describe('test the app service', () => {
     await assertNode.doesNotReject(async () => {
       await helper.copyDir(join(__dirname, 'src'), dest);
     }, 'copyDir should not be rejected');
-    assert.ok(symStub.calledOnce, 'symlink should be caled only once');
+    assert.ok(symStub.calledOnce, 'symlink should be called only once');
   });
 });

--- a/packages/daemon/test/runner/helper.test.ts
+++ b/packages/daemon/test/runner/helper.test.ts
@@ -127,4 +127,13 @@ describe('test the app service', () => {
     sinon.stub(fs, 'chmod');
     await helper.copyDir(src, dest);
   });
+  it('#should copy the symlink successfully', async () => {
+    const src = join(__dirname, './sym.ts');
+    await fs.symlink(join(__dirname, 'helper.test.ts'), src);
+    sinon.stub(fs, 'copyFile');
+    sinon.stub(fs, 'chmod');
+    sinon.stub(fs, 'symlink');
+    await helper.copyDir(__dirname, './dest');
+    await fs.remove(src);
+  });
 });

--- a/packages/daemon/test/runner/helper.test.ts
+++ b/packages/daemon/test/runner/helper.test.ts
@@ -120,4 +120,11 @@ describe('test the app service', () => {
     assert.ok(called, 'function call check');
     assert.ok(throwError, 'error call check');
   });
+  it('#should copy the folder successfully', async () => {
+    const src = './src';
+    const dest = './dest';
+    sinon.stub(fs, 'copyFile');
+    sinon.stub(fs, 'chmod');
+    await helper.copyDir(src, dest);
+  });
 });

--- a/packages/daemon/test/runner/helper.test.ts
+++ b/packages/daemon/test/runner/helper.test.ts
@@ -121,34 +121,31 @@ describe('test the app service', () => {
     assert.ok(called, 'function call check');
     assert.ok(throwError, 'error call check');
   });
-  it('#should copy the folder successfully', async () => {
+  it('#should copy the file successfully', async () => {
     const src = join(__dirname, 'helper.test.ts');
     const dest = join(__dirname, 'dest.ts');
     const copyStub = sinon.stub(fs, 'copyFile');
     const chmodStub = sinon.stub(fs, 'chmod');
-    try {
-      await assertNode.doesNotReject(async () => {
-        await helper.copyDir(src, dest);
-      }, 'copyDir should not be rejected');
-      assert.ok(copyStub.calledOnce, 'copyFile should be caled only once');
-      assert.ok(chmodStub.calledOnce, 'chmod should be caled only once');
-    } finally {
-      await fs.remove(dest);
-    }
+    await assertNode.doesNotReject(async () => {
+      await helper.copyDir(src, dest);
+    }, 'copyDir should not be rejected');
+    assert.ok(copyStub.calledOnce, 'copyFile should be caled only once');
+    assert.ok(chmodStub.calledOnce, 'chmod should be caled only once');
   });
   it('#should copy the symlink successfully', async () => {
-    const src = join(__dirname, 'src', 'sym.ts');
     const dest = join(__dirname, 'dest');
-    try {
-      await fs.ensureSymlink(join(__dirname, 'helper.test.ts'), src);
-      const symStub = sinon.stub(fs, 'symlink');
-      await assertNode.doesNotReject(async () => {
-        await helper.copyDir(join(__dirname, 'src'), dest);
-      }, 'copyDir should not be rejected');
-      assert.ok(symStub.calledOnce, 'symlink should be caled only once');
-    } finally {
-      await fs.remove(src);
-      await fs.remove(dest);
-    }
+    const symStub = sinon.stub(fs, 'symlink').resolves();
+    sinon.stub(fs, 'readlink').resolves();
+    sinon.stub(fs, 'lstat').resolves({
+      isSymbolicLink: () => true,
+      isDirectory: () => false,
+      isFile: () => false,
+      isBlockDevice: () => false,
+      isCharacterDevice: () => false
+    } as any);
+    await assertNode.doesNotReject(async () => {
+      await helper.copyDir(join(__dirname, 'src'), dest);
+    }, 'copyDir should not be rejected');
+    assert.ok(symStub.calledOnce, 'symlink should be caled only once');
   });
 });

--- a/packages/daemon/test/runner/helper.test.ts
+++ b/packages/daemon/test/runner/helper.test.ts
@@ -129,8 +129,8 @@ describe('test the app service', () => {
     await assertNode.doesNotReject(async () => {
       await helper.copyDir(src, dest);
     }, 'copyDir should not be rejected');
-    assert.ok(copyStub.calledOnce, 'copyFile should be caled only once');
-    assert.ok(chmodStub.calledOnce, 'chmod should be caled only once');
+    assert.ok(copyStub.calledOnce, 'copyFile should be called only once');
+    assert.ok(chmodStub.calledOnce, 'chmod should be called only once');
   });
   it('#should copy the symlink successfully', async () => {
     const dest = join(__dirname, 'dest');

--- a/packages/daemon/test/utils/job-runner.test.ts
+++ b/packages/daemon/test/utils/job-runner.test.ts
@@ -6,6 +6,7 @@ import { strict as assert } from 'assert';
 import { JobRunner } from '../../src/runner/job-runner';
 import { JobStatusChangeEvent } from '../../src/service/trace-manager';
 import { JobParam } from '../../src/model/job';
+import * as util from '../../src/utils';
 
 const runner = new JobRunner({
   job: {} as any,
@@ -26,7 +27,7 @@ describe('test JobRunner', () => {
   });
 
   beforeEach(() => {
-    sinon.stub(fs, 'copy').resolves();
+    sinon.stub(util, 'copyDir').resolves();
   });
 
   it('#test getParam with param string and empty extra field', async () => {

--- a/packages/daemon/test/utils/job-runner.test.ts
+++ b/packages/daemon/test/utils/job-runner.test.ts
@@ -26,10 +26,6 @@ describe('test JobRunner', () => {
     sinon.restore();
   });
 
-  beforeEach(() => {
-    sinon.stub(util, 'copyDir').resolves();
-  });
-
   it('#test getParam with param string and empty extra field', async () => {
     assert.deepEqual(runner.getParams('{ "param": "v" }', undefined), { param: 'v' });
   });
@@ -414,6 +410,7 @@ describe('test JobRunner', () => {
     const runModelDefine = sinon.stub(runner, 'runModelDefine').resolves(mockModelDefineResult);
     const runModelTrain = sinon.stub(runner, 'runModelTrain').resolves(mockModelAfterTraining as any);
     const runModelEvaluate = sinon.stub(runner, 'runModelEvaluate').resolves();
+    sinon.stub(util, 'copyDir').resolves();
     await runner.run();
     assert.deepEqual(runDataCollect.args[0],
       [
@@ -475,6 +472,7 @@ describe('test JobRunner', () => {
     const runModelLoad = sinon.stub(runner, 'runModelLoad').resolves(mockModelLoadResult);
     const runModelTrain = sinon.stub(runner, 'runModelTrain').resolves(mockModelAfterTraining as any);
     const runModelEvaluate = sinon.stub(runner, 'runModelEvaluate').resolves();
+    sinon.stub(util, 'copyDir').resolves();
     await runner.run();
     assert.deepEqual(runDataCollect.args[0],
       [

--- a/packages/daemon/test/utils/job-runner.test.ts
+++ b/packages/daemon/test/utils/job-runner.test.ts
@@ -25,6 +25,10 @@ describe('test JobRunner', () => {
     sinon.restore();
   });
 
+  beforeEach(() => {
+    sinon.stub(fs, 'copy').resolves();
+  });
+
   it('#test getParam with param string and empty extra field', async () => {
     assert.deepEqual(runner.getParams('{ "param": "v" }', undefined), { param: 'v' });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4287,7 +4287,7 @@ conventional-recommended-bump@^5.0.0:
     meow "^4.0.0"
     q "^1.5.1"
 
-convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.1, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.1, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==


### PR DESCRIPTION
Refer to Issue #569 

Pipeline works as following now:

provide a plugin-specific working dir for data-collect plugin. One data-collect plugin will download and maintain data in this working dir.

provide the same working dir to data-access plugin. Data-access plugin can also modify contents in this working directory.

This mechanism has the following problems that we hope data-collect plugin can make full use of this working directory. For example, they can reuse existing data, do some data cache, and optimize storage space. But since data-access plugin will also modify the same directory, the data-collect plugin will get lost

To solve this problem, I suggest we keep the current style for data-collect. Meanwhile, we provide a temp directory (job-specific) directory for data-access. This can be removed after the whole job is finished.