### PR TITLE
core: add detail spec for evaluate result

### DIFF
--- a/packages/core/src/types/other.ts
+++ b/packages/core/src/types/other.ts
@@ -3,10 +3,19 @@ export interface Statistic {
   metricValue: number;
 }
 
-export interface EvaluateResult {
+export interface EvaluateResultItem {
   pass?: boolean;
   [key: string]: any;
 }
+
+export interface EvaluateResultOnDatasets {
+  train?: EvaluateResultItem;
+  validate?: EvaluateResultItem;
+  test?: EvaluateResultItem;
+  pass?: boolean;
+}
+
+export type EvaluateResult = EvaluateResultItem | EvaluateResultOnDatasets;
 
 export class EvaluateError extends TypeError {
   public result: EvaluateResult;


### PR DESCRIPTION
Refer to issue #585 

We need to support the evaluation result for both the train and test dataset. This PR is to support this case from the view of core spec. Meanwhile, we will change the plugins to support this feature.