### PR TITLE
boa: don't set PYTHONHOME

### DIFF
--- a/packages/boa/lib/factory.js
+++ b/packages/boa/lib/factory.js
@@ -7,9 +7,6 @@ const { Python } = require('bindings')('boa');
 // read the conda path from the .CONDA_INSTALL_DIR
 // eslint-disable-next-line no-sync
 const condaPath = fs.readFileSync(path.join(__dirname, '../.CONDA_INSTALL_DIR'), 'utf8');
-if (!process.env.PYTHONHOME) {
-  process.env.PYTHONHOME = condaPath;
-}
 
 // create the global-scoped instance
 let pyInst = global.__pipcook_boa_pyinst__;


### PR DESCRIPTION
As https://github.com/alibaba/pipcook/pull/582#issuecomment-706263289 pointed out, this causes spawning with incompatible python(like python2) won't work.