### PR TITLE
boa: use Cloudflare geo api to select mirror automatically

### DIFF
--- a/packages/boa/pybind11/Makefile
+++ b/packages/boa/pybind11/Makefile
@@ -9,7 +9,7 @@ URL=https://github.com/pybind/pybind11/archive/v$(VERSION).tar.gz
 
 ifeq ($(DISABLE_AUTO_SWITCH),)
 	# check the network and switch to corresponding mirror.
-  CCODE := $(shell curl https://api.userinfo.io/userinfos | node ../tools/check-network-env.js)
+	CCODE := $(shell curl https://api.userinfo.io/userinfos | node ../tools/check-network-env.js)
 endif
 UNAME_S := $(shell uname -s)
 

--- a/packages/boa/pybind11/Makefile
+++ b/packages/boa/pybind11/Makefile
@@ -7,13 +7,21 @@ ARCHIVE_DIR="$(ROOT)/downloads/pybind11-$(VERSION)"
 TARBALL="$(ROOT)/downloads/pybind11-v$(VERSION).tgz"
 URL=https://github.com/pybind/pybind11/archive/v$(VERSION).tar.gz
 
+ifeq ($(DISABLE_AUTO_SWITCH),)
+	# check the network and switch to corresponding mirror.
+  CCODE := $(shell curl https://api.userinfo.io/userinfos | node ../tools/check-network-env.js)
+endif
 UNAME_S := $(shell uname -s)
+
 ifeq ($(UNAME_S),Linux)
 	MD5CMD=md5sum --quiet --check checksums
 	DOWNLOAD=wget -O $(TARBALL) $(URL)
 endif
 ifeq ($(UNAME_S), Darwin)
 	DOWNLOAD=curl -L -o $(TARBALL) $(URL)
+endif
+ifeq ($(CCODE),CN)
+	URL=https://pipcook.oss-cn-hangzhou.aliyuncs.com/mirrors/pybind11-$(VERSION).tar.gz
 endif
 
 all: pybind11

--- a/packages/boa/tools/check-network-env.js
+++ b/packages/boa/tools/check-network-env.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function safeParse(data) {
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    return {};
+  }
+}
+
+process.stdin.on('data', (msg) => {
+  const { country } = safeParse(msg);
+  if (country && country.code) {
+    process.stdout.write(country.code);
+  }
+});


### PR DESCRIPTION
Cloudflare provides an API to get the location, we use this API to select the pybind mirror automatically, and the improvements are evident for my location.

__before__

```
$ DISABLE_AUTO_SWITCH=1 time make -C pybind11
49.62 real         0.14 user         0.16 sys
26.11 real         0.06 user         0.12 sys
37.36 real         0.07 user         0.14 sys
33.38 real         0.07 user         0.15 sys
45.23 real         0.08 user         0.16 sys
avg: 38.33
```

__after__

```
$ time make -C pybind11
2.14 real         0.12 user         0.12 sys
1.78 real         0.11 user         0.14 sys
1.34 real         0.09 user         0.15 sys
3.40 real         0.10 user         0.14 sys
1.48 real         0.10 user         0.15 sys
avg: 2.03
```

> Note: added an env `DISABLE_AUTO_SWITCH` to manually disable the switch.