### PR TITLE
CI/CD: Add yarn timeout config to avoid npm install timeout          

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,2 @@
 registry "https://registry.npmjs.com/"
-network-timeout 100000
+network-timeout 60000

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
 registry "https://registry.npmjs.com/"
+network-timeout 100000


### PR DESCRIPTION
As title suggests, this pr is to avoid timeout while installing packages in github action