### PR TITLE
boa: avoid to set @rpath to conda which includes incompatible stdlib

### DIFF
--- a/packages/boa/binding.gyp
+++ b/packages/boa/binding.gyp
@@ -27,11 +27,11 @@
         "<!@(cat .CONDA_INSTALL_DIR)/include/python3.7m",
       ],
       "library_dirs": [
-        "<!@(cat .CONDA_INSTALL_DIR)/lib/cpython",
+        "<!@(cat .CONDA_INSTALL_DIR)/lib",
       ],
       "libraries": [
         "-lpython3.7m",
-        "-Wl,-rpath,'<!@(cat .CONDA_INSTALL_DIR)/lib/cpython'",
+        "-Wl,-rpath,'<!@(cat .CONDA_INSTALL_DIR)/lib'",
       ],
       "defines": [
         "NAPI_CPP_EXCEPTIONS",

--- a/packages/boa/binding.gyp
+++ b/packages/boa/binding.gyp
@@ -16,10 +16,12 @@
         "-fno-rtti",
       ],
       "cflags_cc!": [
-        "-std=c++11",
-        "-stdlib=libc++",
         "-fno-exceptions",
         "-fno-rtti",
+      ],
+      "cflags_cc": [
+        "-std=c++11",
+        "-stdlib=libc++",
       ],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")",
@@ -27,11 +29,11 @@
         "<!@(cat .CONDA_INSTALL_DIR)/include/python3.7m",
       ],
       "library_dirs": [
-        "<!@(cat .CONDA_INSTALL_DIR)/lib",
+        "<!@(cat .CONDA_INSTALL_DIR)/lib/cpython",
       ],
       "libraries": [
         "-lpython3.7m",
-        "-Wl,-rpath,'<!@(cat .CONDA_INSTALL_DIR)/lib'",
+        "-Wl,-rpath,'<!@(cat .CONDA_INSTALL_DIR)/lib/cpython'",
       ],
       "defines": [
         "NAPI_CPP_EXCEPTIONS",

--- a/packages/boa/binding.gyp
+++ b/packages/boa/binding.gyp
@@ -16,12 +16,10 @@
         "-fno-rtti",
       ],
       "cflags_cc!": [
-        "-fno-exceptions",
-        "-fno-rtti",
-      ],
-      "cflags_cc": [
         "-std=c++11",
         "-stdlib=libc++",
+        "-fno-exceptions",
+        "-fno-rtti",
       ],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")",

--- a/packages/boa/tools/install-python.js
+++ b/packages/boa/tools/install-python.js
@@ -43,11 +43,12 @@ if (!fs.existsSync(path.join(CONDA_LOCAL_PATH, 'bin', 'python'))) {
   run('sh', `./${condaDownloadName}`, `-f -b -p ${CONDA_LOCAL_PATH}`);
 }
 
+// cleanup the standard libs.
+if (PLATFORM === 'darwin') {
+  run('rm', `-rf ${CONDA_LOCAL_PATH}/lib/libc++*`);
+}
+
 // dump info
 py(`${CONDA_LOCAL_PATH}/bin/conda`, 'info -a');
 
-// ensure the libpython source.
-run('mkdir', `-p ${CONDA_LOCAL_PATH}/lib/cpython`);
-run('rm', `-rf ${CONDA_LOCAL_PATH}/lib/cpython/*`);
-run('cp', `${CONDA_LOCAL_PATH}/lib/libpython* ${CONDA_LOCAL_PATH}/lib/cpython/`);
 

--- a/packages/boa/tools/install-python.js
+++ b/packages/boa/tools/install-python.js
@@ -32,16 +32,22 @@ if (ARCH === 'x64') {
 }
 condaDownloadName = `${condaDownloadName}.sh`;
 
+// download it if not exists.
 if (!fs.existsSync(condaDownloadName)) {
   run(`curl ${CONDA_DOWNLOAD_PREFIX}/${condaDownloadName} > ${condaDownloadName}`);
 }
 
+// check if ./bin/python exists, if not then install it.
 if (!fs.existsSync(path.join(CONDA_LOCAL_PATH, 'bin', 'python'))) {
   run('rm', `-rf ${CONDA_LOCAL_PATH}`);
   run('sh', `./${condaDownloadName}`, `-f -b -p ${CONDA_LOCAL_PATH}`);
-  run('rm', `-rf ${CONDA_LOCAL_PATH}/lib/libstdc++.so*`);
-  run('rm', `-rf ${CONDA_LOCAL_PATH}/lib/libgcc_s.so*`);
 }
 
 // dump info
 py(`${CONDA_LOCAL_PATH}/bin/conda`, 'info -a');
+
+// ensure the libpython source.
+run('mkdir', `-p ${CONDA_LOCAL_PATH}/lib/cpython`);
+run('rm', `-rf ${CONDA_LOCAL_PATH}/lib/cpython/*`);
+run('cp', `${CONDA_LOCAL_PATH}/lib/libpython* ${CONDA_LOCAL_PATH}/lib/cpython/`);
+

--- a/packages/boa/tools/install-python.js
+++ b/packages/boa/tools/install-python.js
@@ -46,9 +46,10 @@ if (!fs.existsSync(path.join(CONDA_LOCAL_PATH, 'bin', 'python'))) {
 // cleanup the standard libs.
 if (PLATFORM === 'darwin') {
   run('rm', `-rf ${CONDA_LOCAL_PATH}/lib/libc++*`);
+} else if (PLATFORM === 'linux') {
+  run('rm', `-rf ${CONDA_LOCAL_PATH}/lib/libstdc++.so*`);
+  run('rm', `-rf ${CONDA_LOCAL_PATH}/lib/libgcc_s.so*`);
 }
 
 // dump info
 py(`${CONDA_LOCAL_PATH}/bin/conda`, 'info -a');
-
-

--- a/packages/boa/tools/utils.js
+++ b/packages/boa/tools/utils.js
@@ -13,7 +13,11 @@ if (BOA_TUNA && !BOA_CONDA_INDEX) {
   BOA_CONDA_INDEX = 'https://pypi.tuna.tsinghua.edu.cn/simple';
 }
 
-exports.run = (...args) => execSync.call(null, args.join(' '), { stdio: 'inherit' });
+exports.run = (...args) => {
+  const cmd = args.join(' ');
+  console.log(`sh "${cmd}"`);
+  return execSync.call(null, cmd, { stdio: 'inherit' })
+};
 exports.PLATFORM = os.platform();
 exports.ARCH = os.arch();
 


### PR DESCRIPTION
This fixes #639, it's caused by the current miniconda doesn't compile its stdlib for macOS BigSur. With this patch, we are only to use the CPython libraries only when linking dynamically.