### PR TITLE
costa: catch the error when subprocess send failed

### DIFF
--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -183,7 +183,7 @@ export class PluginRunnable {
     this.notRespondTimer = setTimeout(() => {
       this.handle.kill('SIGKILL');
     }, waitForDestroyed);
-    this.send(PluginOperator.WRITE, { event: 'destroy' });
+    await this.send(PluginOperator.WRITE, { event: 'destroy' });
     return new Promise((resolve) => {
       this.ondestroyed = resolve;
     });
@@ -239,7 +239,7 @@ export class PluginRunnable {
    * @param msg
    */
   private async sendAndWait(op: PluginOperator, msg: PluginMessage): Promise<PluginMessage> {
-    this.send(op, msg);
+    await this.send(op, msg);
     debug(`sent ${msg.event} for ${this.id}, and wait for response`);
 
     const resp = await this.waitOn(op);

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -195,11 +195,16 @@ export class PluginRunnable {
    */
   private send(op: PluginOperator, msg?: PluginMessage): Promise<void> {
     const data = PluginProtocol.stringify(op, msg);
-    return new Promise((resolve, reject) => {
-      const rst = this.handle.send(data, (err) => {
+    return new Promise<void>((resolve, reject) => {
+      const success = this.handle.send(data, (err) => {
         err ? reject(err) : resolve();
       });
-      rst || reject(new Error('subprocess send failed'));
+      // if the message queue is full, the result will be false,
+      // and the callback will never been called,
+      // so we need to throw the error here
+      if (!success) {
+        reject(new Error('subprocess send failed'));
+      }
     });
   }
   /**

--- a/packages/costa/src/runnable.ts
+++ b/packages/costa/src/runnable.ts
@@ -214,11 +214,12 @@ export class PluginRunnable {
   /**
    * Do send handshake message to runnable client, and wait for response.
    */
-  private async handshake(): Promise<PluginMessage> {
-    return this.sendAndWait(PluginOperator.START, {
+  private async handshake(): Promise<boolean> {
+    const msg = await this.sendAndWait(PluginOperator.START, {
       event: 'handshake',
       params: [ this.id ]
     });
+    return !!msg;
   }
   /**
    * Wait for the next operator util receiving.


### PR DESCRIPTION
We should set the callback when call `subprocess.send` for catching the asynchronous error.