### PR TITLE
doc: fix the pipboard url

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ pipcook run https://raw.githubusercontent.com/alibaba/pipcook/master/example/p
 If you are wondering what you can do in [Pipcook][] and where you can check your training logs and models, you could start from [Pipboard](https://alibaba.github.io/pipcook/#/GLOSSORY?id=pipboard):
 
 ```
-open https://pipboard.vercel.app/
+open https://imgcook.github.io/pipboard/
 ```
 
 You will see a web page prompt in your browser, and there is a MNIST showcase on the home page and play around there. 


### PR DESCRIPTION
We have migrated the Pipboard from vercel to GitHub pages, this corrects the pipboard URI.