### PR TITLE
esbuild: ignore *.md

### DIFF
--- a/.github/workflows/esbuild.yml
+++ b/.github/workflows/esbuild.yml
@@ -8,6 +8,7 @@ on:
     - 'docs/**'
     - 'notebooks/**'
     - '.github/markdown.yml'
+    - '*.md'
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
     branches:
@@ -17,6 +18,7 @@ on:
     - 'docs/**'
     - 'notebooks/**'
     - '.github/markdown.yml'
+    - '*.md'
 
 jobs:
   universal:


### PR DESCRIPTION
README.md is not source code file, so its changes should not trigger the build like `tsc-build`.