### PR TITLE
boa: enable python version switch in manual way

### DIFF
--- a/packages/boa/binding.gyp
+++ b/packages/boa/binding.gyp
@@ -24,19 +24,20 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")",
         "pybind11/src/include",
-        "<!@(node -p \"require('./tools/utils').getCondaPath()\")/include/python3.7m",
+        "<!@(node -p \"require('./tools/utils').getPythonHeaderPath()\")",
       ],
       "library_dirs": [
         "<!@(node -p \"require('./tools/utils').getCondaPath()\")/lib",
       ],
       "libraries": [
-        "-lpython3.7m",
+        "-lpython<!@(node -p \"require('./tools/utils').getPythonVersion()\")",
         "-Wl,-rpath,'<!@(node -p \"require('./tools/utils').getCondaPath()\")/lib'",
       ],
       "defines": [
         "NAPI_CPP_EXCEPTIONS",
         "NAPI_EXPERIMENTAL",
         "NAPI_VERSION=6",
+        "BOA_LIBPYTHON_NAME=python<!@(node -p \"require('./tools/utils').getPythonVersion()\")"
       ],
       "conditions": [
         ['OS=="mac"', {

--- a/packages/boa/src/binding.cc
+++ b/packages/boa/src/binding.cc
@@ -4,18 +4,33 @@
 #include <dlfcn.h>
 #include <napi.h>
 
+#define _CONCAT_NX(NAME, POSTFIX) lib ## NAME ## POSTFIX
+#define _CONCAT(NAME, POSTFIX) _CONCAT_NX(NAME, POSTFIX)
+#define _STRINGIZE_NX(S) #S
+#define _STRINGIZE(S) _STRINGIZE_NX(S)
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   // Preload the Python library for resolving numpy tracky issue.
 #if defined(__APPLE__) || defined(__MACH__)
-  dlopen("libpython3.7m.dylib", RTLD_LAZY | RTLD_GLOBAL);
+  char const* libpython = _STRINGIZE(_CONCAT(BOA_LIBPYTHON_NAME, .dylib));
 #elif defined(__linux__) || defined(__unix__)
-  dlopen("libpython3.7m.so", RTLD_LAZY | RTLD_GLOBAL);
+  char const* libpython = _STRINGIZE(_CONCAT(BOA_LIBPYTHON_NAME, .so));
 #endif
+  void* r = dlopen(libpython, RTLD_LAZY | RTLD_GLOBAL);
+  if (r == NULL) {
+  	Error::New(env, "dlopen libpython failed.").ThrowAsJavaScriptException();
+    return exports;
+  }
 
   boa::PythonNode::Init(env, exports);
   boa::PythonModule::Init(env, exports);
   boa::PythonObject::Init(env, exports);
   return exports;
 }
+
+#undef _CONCAT_NX
+#undef _CONCAT
+#undef _STRINGIZE_NX
+#undef _STRINGIZE
 
 NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/packages/boa/src/binding.cc
+++ b/packages/boa/src/binding.cc
@@ -4,7 +4,7 @@
 #include <dlfcn.h>
 #include <napi.h>
 
-#define _CONCAT_NX(NAME, POSTFIX) lib ## NAME ## POSTFIX
+#define _CONCAT_NX(NAME, POSTFIX) lib##NAME##POSTFIX
 #define _CONCAT(NAME, POSTFIX) _CONCAT_NX(NAME, POSTFIX)
 #define _STRINGIZE_NX(S) #S
 #define _STRINGIZE(S) _STRINGIZE_NX(S)
@@ -12,11 +12,11 @@
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   // Preload the Python library for resolving numpy tracky issue.
 #if defined(__APPLE__) || defined(__MACH__)
-  char const* libpython = _STRINGIZE(_CONCAT(BOA_LIBPYTHON_NAME, .dylib));
+  char const *libpython = _STRINGIZE(_CONCAT(BOA_LIBPYTHON_NAME, .dylib));
 #elif defined(__linux__) || defined(__unix__)
-  char const* libpython = _STRINGIZE(_CONCAT(BOA_LIBPYTHON_NAME, .so));
+  char const *libpython = _STRINGIZE(_CONCAT(BOA_LIBPYTHON_NAME, .so));
 #endif
-  void* r = dlopen(libpython, RTLD_LAZY | RTLD_GLOBAL);
+  void *r = dlopen(libpython, RTLD_LAZY | RTLD_GLOBAL);
   if (r == NULL) {
     Error::New(env, "dlopen libpython failed.").ThrowAsJavaScriptException();
     return exports;

--- a/packages/boa/src/binding.cc
+++ b/packages/boa/src/binding.cc
@@ -18,7 +18,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 #endif
   void* r = dlopen(libpython, RTLD_LAZY | RTLD_GLOBAL);
   if (r == NULL) {
-  	Error::New(env, "dlopen libpython failed.").ThrowAsJavaScriptException();
+    Error::New(env, "dlopen libpython failed.").ThrowAsJavaScriptException();
     return exports;
   }
 

--- a/packages/boa/tools/install-python.js
+++ b/packages/boa/tools/install-python.js
@@ -13,7 +13,7 @@ if (process.env.BOA_CONDA_MIRROR) {
 }
 
 const CONDA_LOCAL_PATH = initAndGetCondaPath();
-let condaDownloadName = 'Miniconda3-4.7.12.1';
+let condaDownloadName = process.env.CONDA_PACKAGE_NAME || 'Miniconda3-4.7.12.1';
 
 if (PLATFORM === 'linux') {
   condaDownloadName += '-Linux';


### PR DESCRIPTION
This PR tries to remove the specific version from the source code and gyp config, to switch the python version, change the function `getPythonVersion()` in tools/utils.js.

And I also add a TODO which is able to automatically detect the python library name from the corresponding conda source, which will be done in the next PR.