### PR TITLE
cli: add new command to use create-pipcook-plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,9 @@ jobs:
     - name: Pipcook plugin development
       run: |
         ./packages/cli/dist/bin/pipcook plugin-dev -t dataCollect
+        ./packages/cli/dist/bin/pipcook plugin create foobar
+        ./packages/cli/dist/bin/pipcook plugin create foobar2 --category data-collect
+        ./packages/cli/dist/bin/pipcook plugin create foobar3 --python
     - name: Daemon start on customized port
       run: |
         ./packages/cli/dist/bin/pipcook daemon stop

--- a/docs/contributing/contribute-a-plugin.md
+++ b/docs/contributing/contribute-a-plugin.md
@@ -6,10 +6,10 @@ We strongly recommend that you first understand the [plugin specification](../sp
 
 ## Get Started
 
-To get started with developing a new plugin, [Pipcook Tools][] provides `pipcook plugin-dev`:
+To get started with developing a new plugin, [Pipcook Tools][] provides `pipcook plugin create`:
 
 ```sh
-$ pipcook plugin-dev --type <category> --name <plugin>
+$ pipcook plugin create --category <name> foobar
 ```
 
 A plugin script is a TypeScript function that inherits from the corresponding plugin interface, for exmaple, a `DataCollectType` plugin will look like this:
@@ -78,6 +78,12 @@ In this way, when Pipcook loads the plugin, it will use the Python loader to loa
     }
   }
 }
+```
+
+You can also quickly initialize a Python plugin via the command line:
+
+```sh
+$ pipcook plugin create foobar --python
 ```
 
 ## Release

--- a/docs/zh-cn/contributing/contribute-a-plugin.md
+++ b/docs/zh-cn/contributing/contribute-a-plugin.md
@@ -9,7 +9,7 @@ Pipcook 乐于开发者为我们贡献插件以扩展 Pipcook 的功能。 本�
 插件开发从一行命令开始：`pipcook plugin-dev`：
 
 ```sh
-$ pipcook plugin-dev --type <category> --name <plugin>
+$ pipcook plugin create --category <name> foobar
 ```
 
 一个插件就是一个继承自 Pipcook 插件接口的 TypeScript 函数，比如一个 `DataCollectType` 插件：
@@ -77,6 +77,12 @@ Pipcook 约定 `main` 函数作为了插件的入口，参数与 Node.js 插件�
     }
   }
 }
+```
+
+也可以通过命令行快速初始化一个 Python 插件：
+
+```sh
+$ pipcook plugin create foobar --python
 ```
 
 ## 发布

--- a/docs/zh-cn/contributing/contribute-a-plugin.md
+++ b/docs/zh-cn/contributing/contribute-a-plugin.md
@@ -6,7 +6,7 @@ Pipcook 乐于开发者为我们贡献插件以扩展 Pipcook 的功能。 本�
 
 ## 新手入门
 
-插件开发从一行命令开始：`pipcook plugin-dev`：
+插件开发从一行命令开始：`pipcook plugin create`：
 
 ```sh
 $ pipcook plugin create --category <name> foobar

--- a/packages/cli/src/actions/dev-plugin.ts
+++ b/packages/cli/src/actions/dev-plugin.ts
@@ -10,6 +10,7 @@ import { logger } from '../utils/common';
  * prepare a working dir for developer to develop plugins
  */
 const devPlugin: DevPluginCommandHandler = async ({ type, name }) => {
+  console.warn('`pipcook plugin-dev` is deprecated, please use `pipcook plugin create`.');
   if (!type) {
     console.log('Please provide a plugin type');
     return process.exit(1);

--- a/packages/cli/src/bin/pipcook-plugin.ts
+++ b/packages/cli/src/bin/pipcook-plugin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import * as program from 'commander';
-import { install, uninstall, list, info } from '../service/plugin';
+import { install, uninstall, list, info, create } from '../service/plugin';
 
 program
   .command('install <name>')
@@ -40,4 +40,11 @@ program
   .option('-h|--host-ip <ip>', 'the host ip of daemon')
   .option('-p|--port <port>', 'the port of daemon')
   .action(info);
+
+program
+  .command('create <plugin-directory>')
+  .description('create a new plugin')
+  .allowUnknownOption()
+  .action(create);
+
 program.parse(process.argv);

--- a/packages/cli/src/service/plugin.ts
+++ b/packages/cli/src/service/plugin.ts
@@ -159,3 +159,8 @@ export async function info(id: string, opts: any): Promise<void> {
     logger.fail(err.message);
   }
 }
+
+export async function create(dir: string, opts: any): Promise<void> {
+  const args = ['init', '@pipcook/pipcook-plugin'].concat(opts.parent.rawArgs.slice(3));
+  spawnSync('npm', args, { stdio: 'inherit' });
+}

--- a/packages/cli/src/service/plugin.ts
+++ b/packages/cli/src/service/plugin.ts
@@ -161,6 +161,6 @@ export async function info(id: string, opts: any): Promise<void> {
 }
 
 export async function create(dir: string, opts: any): Promise<void> {
-  const args = ['init', '@pipcook/pipcook-plugin'].concat(opts.parent.rawArgs.slice(3));
+  const args = [ 'init', '@pipcook/pipcook-plugin' ].concat(opts.parent.rawArgs.slice(3));
   spawnSync('npm', args, { stdio: 'inherit' });
 }


### PR DESCRIPTION
See https://github.com/imgcook/create-pipcook-plugin. This PR adds a new command to use create-pipcook-plugin to improve the UX for plugin developers:

```sh
$ pipcook plugin create foobar --category data-collect
```

This deprecated the old `dev-plugin` command which will be removed at 2.0 :)