### PR TITLE
cli: check if BOOTSTRAP_HOME exists before starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ __pycache__
 *.pb
 coverage
 .nyc_output
+package-lock.json
+

--- a/packages/cli/src/bin/pipcook-daemon.ts
+++ b/packages/cli/src/bin/pipcook-daemon.ts
@@ -26,6 +26,9 @@ interface DaemonBootstrapMessage {
 }
 
 async function start(): Promise<void> {
+  if (!await pathExists(BOOTSTRAP_HOME)) {
+    return logger.fail('"pipcook init" is required.');
+  }
   // check if the process is running...
   if (await pathExists(DAEMON_PIDFILE)) {
     return logger.fail(`starting daemon but ${DAEMON_PIDFILE} exists.`);


### PR DESCRIPTION
This PR checks for the BOOTSTRAP_HOME and prints a readable log instead of the stack trace.