### PR TITLE
build: use new syntax to update env in workflow

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -32,7 +32,7 @@ jobs:
             echo "Last commit is made @ $date"
             
             if [ -n "${date}" ]; then
-              echo ::set-env name=UPDATED::true
+              echo "UPDATED=true" >> $GITHUB_ENV
             fi
         shell: bash
 


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ for more details.

It addresses this problem at https://github.com/alibaba/pipcook/pull/655#issuecomment-741675083.