### PR TITLE
notebook: upgrade the nodejs version to 12.19

### DIFF
--- a/notebooks/pipcook_image_classification.ipynb
+++ b/notebooks/pipcook_image_classification.ipynb
@@ -34,20 +34,20 @@
         "colab": {}
       },
       "source": [
-        "!wget -P /tmp https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-x64.tar.xz\n",
+        "!wget -P /tmp https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz\n",
         "!rm -rf /usr/local/lib/nodejs\n",
         "!mkdir -p /usr/local/lib/nodejs\n",
-        "!tar -xJf /tmp/node-v12.18.1-linux-x64.tar.xz -C /usr/local/lib/nodejs\n",
-        "!sh -c 'echo \"export PATH=/usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin:\\$PATH\" >> /etc/profile'\n",
+        "!tar -xJf /tmp/node-v12.19.0-linux-x64.tar.xz -C /usr/local/lib/nodejs\n",
+        "!sh -c 'echo \"export PATH=/usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin:\\$PATH\" >> /etc/profile'\n",
         "!rm -f /usr/bin/node\n",
         "!rm -f /usr/bin/npm\n",
-        "!ln -s /usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin/node /usr/bin/node\n",
-        "!ln -s /usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin/npm /usr/bin/npm\n",
+        "!ln -s /usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin/node /usr/bin/node\n",
+        "!ln -s /usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin/npm /usr/bin/npm\n",
         "!npm config delete registry\n",
         "\n",
         "import os\n",
         "PATH_ENV = os.environ['PATH']\n",
-        "%env PATH=/usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin:${PATH_ENV}"
+        "%env PATH=/usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin:${PATH_ENV}"
       ],
       "execution_count": null,
       "outputs": []
@@ -73,7 +73,7 @@
       "source": [
         "!npm install @pipcook/pipcook-cli -g\n",
         "!rm -f /usr/bin/pipcook\n",
-        "!ln -s /usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin/pipcook /usr/bin/pipcook"
+        "!ln -s /usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin/pipcook /usr/bin/pipcook"
       ],
       "execution_count": null,
       "outputs": []

--- a/notebooks/pipcook_object_detection.ipynb
+++ b/notebooks/pipcook_object_detection.ipynb
@@ -33,20 +33,20 @@
         "colab": {}
       },
       "source": [
-        "!wget -P /tmp https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-x64.tar.xz\n",
+        "!wget -P /tmp https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz\n",
         "!rm -rf /usr/local/lib/nodejs\n",
         "!mkdir -p /usr/local/lib/nodejs\n",
-        "!tar -xJf /tmp/node-v12.18.1-linux-x64.tar.xz -C /usr/local/lib/nodejs\n",
-        "!sh -c 'echo \"export PATH=/usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin:\\$PATH\" >> /etc/profile'\n",
+        "!tar -xJf /tmp/node-v12.19.0-linux-x64.tar.xz -C /usr/local/lib/nodejs\n",
+        "!sh -c 'echo \"export PATH=/usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin:\\$PATH\" >> /etc/profile'\n",
         "!rm -f /usr/bin/node\n",
         "!rm -f /usr/bin/npm\n",
-        "!ln -s /usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin/node /usr/bin/node\n",
-        "!ln -s /usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin/npm /usr/bin/npm\n",
+        "!ln -s /usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin/node /usr/bin/node\n",
+        "!ln -s /usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin/npm /usr/bin/npm\n",
         "!npm config delete registry\n",
         "\n",
         "import os\n",
         "PATH_ENV = os.environ['PATH']\n",
-        "%env PATH=/usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin:${PATH_ENV}"
+        "%env PATH=/usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin:${PATH_ENV}"
       ],
       "execution_count": null,
       "outputs": []

--- a/notebooks/pipcook_object_detection.ipynb
+++ b/notebooks/pipcook_object_detection.ipynb
@@ -309,7 +309,7 @@
         "colab": {}
       },
       "source": [
-        "!sudo pipcook run https://raw.githubusercontent.com/alibaba/pipcook/master/example/pipelines/object-detection.json"
+        "!sudo pipcook run https://raw.githubusercontent.com/alibaba/pipcook/main/example/pipelines/object-detection-yolov5.json"
       ],
       "execution_count": null,
       "outputs": []

--- a/notebooks/pipcook_object_detection.ipynb
+++ b/notebooks/pipcook_object_detection.ipynb
@@ -72,7 +72,7 @@
       "source": [
         "!npm install @pipcook/pipcook-cli -g\n",
         "!rm -f /usr/bin/pipcook\n",
-        "!ln -s /usr/local/lib/nodejs/node-v12.18.1-linux-x64/bin/pipcook /usr/bin/pipcook"
+        "!ln -s /usr/local/lib/nodejs/node-v12.19.0-linux-x64/bin/pipcook /usr/bin/pipcook"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
As we have upgraded to the v1.3.0, it validates the Node.js version to be bigger than 10.19.