### PR TITLE
build: make boa work with Node10 and NAPI3

### DIFF
--- a/packages/boa/binding.gyp
+++ b/packages/boa/binding.gyp
@@ -35,8 +35,6 @@
       ],
       "defines": [
         "NAPI_CPP_EXCEPTIONS",
-        "NAPI_EXPERIMENTAL",
-        "NAPI_VERSION=6",
         "BOA_LIBPYTHON_NAME=python<!@(node -p \"require('./tools/utils').getPythonVersion()\")"
       ],
       "conditions": [

--- a/packages/boa/lib/worker.js
+++ b/packages/boa/lib/worker.js
@@ -8,9 +8,15 @@ const { PythonObject, NODE_PYTHON_HANDLE_NAME } = require('bindings')('boa');
 const { wrap } = require('./proxy');
 
 const TYPE_ID = 'SHARED_PYTHON_OBJECT_TYPE';
-if (process.moduleLoadList.indexOf('NativeModule worker_threads') > 0) {
-  ({ isMainThread, workerData } = require('worker_threads'));
+try {
+  require.resolve('worker_threads');
   supportWorkerThreads = true;
+} catch (err) {
+  supportWorkerThreads = false;
+}
+
+if (supportWorkerThreads === true) {
+  ({ isMainThread, workerData } = require('worker_threads'));
 }
 
 /**

--- a/packages/boa/lib/worker.js
+++ b/packages/boa/lib/worker.js
@@ -1,10 +1,17 @@
 'use strict';
 
-const { isMainThread, workerData } = require('worker_threads');
+let isMainThread = false;
+let workerData = null;
+let supportWorkerThreads = false;
+
 const { PythonObject, NODE_PYTHON_HANDLE_NAME } = require('bindings')('boa');
 const { wrap } = require('./proxy');
 
 const TYPE_ID = 'SHARED_PYTHON_OBJECT_TYPE';
+if (process.moduleLoadList.indexOf('NativeModule worker_threads') > 0) {
+  [isMainThread, workerData] = require('worker_threads');
+  supportWorkerThreads = true;
+}
 
 /**
  * This is a wrapper for shared Python object, just like
@@ -12,8 +19,11 @@ const TYPE_ID = 'SHARED_PYTHON_OBJECT_TYPE';
  */
 class SharedPythonObject {
   constructor(o) {
+    if (!supportWorkerThreads) {
+      throw new TypeError('worker_threads is not supported, please upgrade your Node.js');
+    }
     if (!isMainThread) {
-      throw TypeError('SharedPythonObject must be used in main thread.');
+      throw new TypeError('SharedPythonObject must be used in main thread.');
     }
     this.ownershipId = o[NODE_PYTHON_HANDLE_NAME].requestOwnership();
     this.__type__ = TYPE_ID;

--- a/packages/boa/lib/worker.js
+++ b/packages/boa/lib/worker.js
@@ -9,7 +9,7 @@ const { wrap } = require('./proxy');
 
 const TYPE_ID = 'SHARED_PYTHON_OBJECT_TYPE';
 if (process.moduleLoadList.indexOf('NativeModule worker_threads') > 0) {
-  [isMainThread, workerData] = require('worker_threads');
+  ({ isMainThread, workerData } = require('worker_threads'));
   supportWorkerThreads = true;
 }
 

--- a/packages/boa/package.json
+++ b/packages/boa/package.json
@@ -53,7 +53,8 @@
     "eslint": "^7.15.0",
     "nyc": "^15.1.0",
     "tape": "^5.0.1",
-    "ts-node": "^8.6.2"
+    "ts-node": "^8.6.2",
+    "typescript": "^4.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/boa/package.json
+++ b/packages/boa/package.json
@@ -53,8 +53,7 @@
     "eslint": "^7.15.0",
     "nyc": "^15.1.0",
     "tape": "^5.0.1",
-    "ts-node": "^8.6.2",
-    "typescript": "^4.1.3"
+    "ts-node": "^8.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/boa/src/core/object.cc
+++ b/packages/boa/src/core/object.cc
@@ -46,10 +46,8 @@ Object PythonObject::Init(Napi::Env env, Object exports) {
           InstanceMethod("__delitem__", &PythonObject::DelItem),
       });
 
-  // Napi::FunctionReference *constructor = new Napi::FunctionReference();
   constructor = Persistent(func);
   constructor.SuppressDestruct();
-  // env.SetInstanceData(constructor);
 
   exports.Set("PythonObject", func);
 #define DEFINE_CONSTANT(macro) exports.Set(#macro, macro)
@@ -66,8 +64,6 @@ Object PythonObject::Init(Napi::Env env, Object exports) {
 
 Object PythonObject::NewInstance(Napi::Env env, pybind::object src) {
   return constructor.New({External<pybind::object>::New(env, &src)});
-  // return env.GetInstanceData<Napi::FunctionReference>()->New(
-  //    {External<pybind::object>::New(env, &src)});
 }
 
 PythonObject::PythonObject(const CallbackInfo &info)

--- a/packages/boa/src/core/object.cc
+++ b/packages/boa/src/core/object.cc
@@ -49,14 +49,16 @@ Object PythonObject::Init(Napi::Env env, Object exports) {
       });
 
   /**
-   * See https://github.com/nodejs/node-addon-examples/commit/dc86a662c27c5732e069e1c19d3b7a8e74e86d29
-   * `worker_threads` requires addon to be context-sensistive, otherwise downgrade to static constructor.
+   * See
+   * https://github.com/nodejs/node-addon-examples/commit/dc86a662c27c5732e069e1c19d3b7a8e74e86d29
+   * `worker_threads` requires addon to be context-sensistive, otherwise
+   * downgrade to static constructor.
    */
 #if (NAPI_VERSION < 5)
   constructor = Persistent(func);
   constructor.SuppressDestruct();
 #else
-  FunctionReference* constructor = new FunctionReference();
+  FunctionReference *constructor = new FunctionReference();
   *constructor = Persistent(func);
   env.SetInstanceData(constructor);
 #endif
@@ -80,7 +82,7 @@ Object PythonObject::NewInstance(Napi::Env env, pybind::object src) {
   auto instance = constructor.New({External<pybind::object>::New(env, &src)});
 #else
   auto instance = env.GetInstanceData<FunctionReference>()->New(
-    {External<pybind::object>::New(env, &src)});
+      {External<pybind::object>::New(env, &src)});
 #endif
   return scope.Escape(napi_value(instance)).ToObject();
 }

--- a/packages/boa/src/core/object.h
+++ b/packages/boa/src/core/object.h
@@ -17,7 +17,6 @@ public:
   pybind::object value();
 
 private:
-  static FunctionReference constructor;
   Napi::Value Next(const CallbackInfo &);
   Napi::Value Invoke(const CallbackInfo &);
   Napi::Value CreateClass(const CallbackInfo &);
@@ -68,6 +67,11 @@ private:
   ObjectOwnership<PyObject> *_ownership = nullptr;
   uintptr_t _borrowedOwnershipId = 0x0;
   std::vector<PythonFunction *> _funcs;
+
+#if (NAPI_VERSION < 5)
+private:
+  static FunctionReference constructor;
+#endif
 };
 
 } // namespace boa

--- a/packages/boa/src/core/object.h
+++ b/packages/boa/src/core/object.h
@@ -17,6 +17,7 @@ public:
   pybind::object value();
 
 private:
+  static FunctionReference constructor;
   Napi::Value Next(const CallbackInfo &);
   Napi::Value Invoke(const CallbackInfo &);
   Napi::Value CreateClass(const CallbackInfo &);

--- a/packages/boa/tests/base/async.js
+++ b/packages/boa/tests/base/async.js
@@ -1,4 +1,7 @@
-if (process.moduleLoadList.indexOf('NativeModule worker_threads') === -1) {
+// check if worker_threads is enabled.
+try {
+  require.resolve('worker_threads');
+} catch (e) {
   console.log('just skip the module because worker_threads not found');
   return;
 }

--- a/packages/boa/tests/base/async.js
+++ b/packages/boa/tests/base/async.js
@@ -1,7 +1,6 @@
 if (process.moduleLoadList.indexOf('NativeModule worker_threads') === -1) {
   console.log('just skip the module because worker_threads not found');
-  // eslint-disable-next-line no-process-exit
-  return process.exit(0);
+  return;
 }
 
 const test = require('tape');

--- a/packages/boa/tests/base/async.js
+++ b/packages/boa/tests/base/async.js
@@ -1,3 +1,9 @@
+if (process.moduleLoadList.indexOf('NativeModule worker_threads') === -1) {
+  console.log('just skip the module because worker_threads not found');
+  // eslint-disable-next-line no-process-exit
+  return process.exit(0);
+}
+
 const test = require('tape');
 const { Worker, isMainThread, workerData, parentPort } = require('worker_threads');
 const boa = require('../../');

--- a/packages/boa/tools/check-dependence.js
+++ b/packages/boa/tools/check-dependence.js
@@ -2,12 +2,6 @@
 
 'use strict';
 const { run, PLATFORM } = require('./utils');
-
-const majorVersion = process.version.split('.')[0];
-if (parseInt(majorVersion.substr(1)) < 12) {
-  throw new TypeError(`require Node.js >= v12.0.0, but ${process.version} found`);
-}
-
 const cmds = [ 'rm', 'make', 'tar' ];
 
 if (PLATFORM === 'linux') {


### PR DESCRIPTION
Node.js 12 requires a higher GLIBC, which won't be supported on some platforms, thus this PR downgrades the Node.js and NAPI requirements. Now the boa is able to work with Node.js 10.13 and NAPI3.