### PR TITLE
esbuild: disable test for esbuild

### DIFF
--- a/.github/workflows/esbuild.yml
+++ b/.github/workflows/esbuild.yml
@@ -40,7 +40,3 @@ jobs:
         yarn build
         yarn dev-build
         mkdir -p ~/.pipcook/db && yarn workspace @pipcook/daemon run migrate
-    - name: Running unit tests
-      run: |
-        yarn init-dev
-        yarn test


### PR DESCRIPTION
There is a difference between esbuild and TSC in module import:
origin code:
```js
import * as fs from 'fs';
```
tsc:
```js
const fs = require('fs');
```

esbuild:
```js
const fs = __toModule(require('fs'));
```

This makes the `sinon.stub` invalid. So we disable the test for esbuild, we will enable it again if esbuild supports to disable `esModuleInterop`.