### PR TITLE
fix copyFile block with option COPYFILE_FICLONE

### DIFF
--- a/packages/daemon/src/utils.ts
+++ b/packages/daemon/src/utils.ts
@@ -3,6 +3,8 @@ import { Context } from 'midway';
 import SseStream from 'ssestream';
 import * as path from 'path';
 import * as fs from 'fs-extra';
+import { copyFile } from 'fs';
+import * as util from 'util';
 import * as request from 'request-promise';
 import * as url from 'url';
 import {
@@ -10,6 +12,8 @@ import {
   generateId
 } from '@pipcook/pipcook-core';
 import { PipelineEntity } from './model/pipeline';
+
+export const copyFileAsync = util.promisify(copyFile);
 
 export class ServerSentEmitter {
   private handle: SseStream;
@@ -106,7 +110,7 @@ export async function copyDir(src: string, dest: string): Promise<void> {
   };
 
   const onFile = async (src: string, dest: string, mode: number) => {
-    await fs.copyFile(src, dest, fs.constants.COPYFILE_FICLONE);
+    await copyFileAsync(src, dest, fs.constants.COPYFILE_FICLONE);
     await fs.chmod(dest, mode);
   };
 

--- a/packages/daemon/test/runner/helper.test.ts
+++ b/packages/daemon/test/runner/helper.test.ts
@@ -124,7 +124,7 @@ describe('test the app service', () => {
   it('#should copy the file successfully', async () => {
     const src = join(__dirname, 'helper.test.ts');
     const dest = join(__dirname, 'dest.ts');
-    const copyStub = sinon.stub(fs, 'copyFile');
+    const copyStub = sinon.stub(helper, 'copyFileAsync');
     const chmodStub = sinon.stub(fs, 'chmod');
     await assertNode.doesNotReject(async () => {
       await helper.copyDir(src, dest);


### PR DESCRIPTION
Fix: `fs.copyFile(src, dest, fs.constants.COPYFILE_FICLONE)`  blocks the promise train, because `grancful-fs` which is depended by `fs-extra` misses the callback function. see:
https://github.com/isaacs/node-graceful-fs/pull/202