### PR TITLE
cli: fix file protocol uri with query

### DIFF
--- a/packages/cli/src/utils/script.test.ts
+++ b/packages/cli/src/utils/script.test.ts
@@ -50,6 +50,20 @@ test.serial('download script with file protocol', async (t) => {
   );
 });
 
+test.serial('download script with file protocol and query', async (t) => {
+  const localPath = process.cwd();
+  const url = 'file:///data/a.js?a=1&b=http://a.b.c';
+  const enableCache = true;
+  const stubCopy = sinon.stub(fs, 'copy').resolves();
+  await script.downloadScript(localPath, 1, url, ScriptType.Model, enableCache);
+  t.true(stubCopy.calledOnce, 'fs.copy should be called once');
+  t.deepEqual(
+    stubCopy.args[0],
+    [ '/data/a.js', `${localPath}/1-a.js` ] as any,
+    'fs.copy should called with currect args'
+  );
+});
+
 async function runPrepare(t: any, enableCache: boolean, withDataflow: boolean) {
   const pipelineMeta: PipelineMeta = {
     'specVersion': '2.0',

--- a/packages/cli/src/utils/script.ts
+++ b/packages/cli/src/utils/script.ts
@@ -19,8 +19,7 @@ export const downloadScript = async (scriptDir: string, scriptOrder: number, url
   const query = queryString.parse(urlObj.query);
   // if the url is is file protocol, copy without cache
   if (urlObj.protocol === DownloadProtocol.FILE) {
-    const p = urlObj.path.split('?')[0];
-    await fs.copy(p, localPath);
+    await fs.copy(urlObj.pathname, localPath);
   } else {
     if (urlObj.protocol === DownloadProtocol.HTTP || urlObj.protocol === DownloadProtocol.HTTPS) {
       // maybe should copy the script with COW

--- a/packages/cli/src/utils/script.ts
+++ b/packages/cli/src/utils/script.ts
@@ -19,7 +19,8 @@ export const downloadScript = async (scriptDir: string, scriptOrder: number, url
   const query = queryString.parse(urlObj.query);
   // if the url is is file protocol, copy without cache
   if (urlObj.protocol === DownloadProtocol.FILE) {
-    await fs.copy(urlObj.path, localPath);
+    const p = urlObj.path.split('?')[0];
+    await fs.copy(p, localPath);
   } else {
     if (urlObj.protocol === DownloadProtocol.HTTP || urlObj.protocol === DownloadProtocol.HTTPS) {
       // maybe should copy the script with COW


### PR DESCRIPTION
We should use `url.pathname` to get the real path so that support the query string.