### PR TITLE
cli: fix cli version error

### DIFF
--- a/packages/cli/src/bin/pipcook.ts
+++ b/packages/cli/src/bin/pipcook.ts
@@ -81,7 +81,7 @@ export const cacheClean = async (opts: CacheCleanOptions): Promise<void> => {
     return;
   }
 
-  const pkg = await readJson(join(__filename, '../../package.json'));
+  const pkg = await readJson(join(__filename, '../../../package.json'));
   program.version(pkg.version, '-v, --version');
 
   program

--- a/packages/cli/tools/setup.sh
+++ b/packages/cli/tools/setup.sh
@@ -1,5 +1,3 @@
-cp ./package.json ./dist/
-
 enable_cmd() {
   cp ./dist/bin/$1.js ./dist/bin/$1
   chmod +x ./dist/bin/$1


### PR DESCRIPTION
Read from `package.json` at the root directory to make true we can get the correct version string.