### PR TITLE
cli: fix fetch with cache

### DIFF
--- a/packages/cli/src/utils/cache.test.ts
+++ b/packages/cli/src/utils/cache.test.ts
@@ -18,10 +18,10 @@ test.serial('fetch with cache', async (t) => {
 
   await fetchWithCache(cacheDir, url, target);
 
-  t.false(stubDownloadAndExtractTo.called);
-  t.true(stubRemove.calledOnce);
-  t.true(stubPathExists.calledOnce);
-  t.true(stubSymlink.called);
+  t.false(stubDownloadAndExtractTo.called, 'downloadAndExtractTo function should not called.');
+  t.true(stubRemove.calledOnce, 'fs.remove function should called once.');
+  t.true(stubPathExists.calledOnce, 'fs.pathExists function should called once.');
+  t.true(stubSymlink.called, 'fs.symlink function should called.');
 });
 
 test.serial('fetch with missed cache', async (t) => {
@@ -31,15 +31,17 @@ test.serial('fetch with missed cache', async (t) => {
 
   const stubDownloadAndExtractTo = sinon.stub(utils, 'downloadAndExtractTo').resolves();
   const stubRemove = sinon.stub(fs, 'remove').resolves();
+  const stubMove = sinon.stub(fs, 'move').resolves();
   const stubPathExists = sinon.stub(fs, 'pathExists').resolves(false);
   const stubSymlink = sinon.stub(fs, 'symlink').resolves();
 
   await fetchWithCache(cacheDir, url, target);
 
-  t.true(stubDownloadAndExtractTo.calledOnce);
-  t.true(stubRemove.calledTwice);
-  t.true(stubPathExists.calledOnce);
-  t.true(stubSymlink.calledOnce);
+  t.true(stubDownloadAndExtractTo.calledOnce, 'downloadAndExtractTo function should called once.');
+  t.true(stubRemove.calledThrice, 'fs.remove function should three times.');
+  t.true(stubMove.calledOnce, 'fs.move function should called once.');
+  t.true(stubPathExists.calledOnce, 'fs.pathExists function should called once.');
+  t.true(stubSymlink.calledOnce, 'fs.symlink function should called once.');
 });
 
 test.serial('fetch with disabled cache', async (t) => {
@@ -49,13 +51,15 @@ test.serial('fetch with disabled cache', async (t) => {
 
   const stubDownloadAndExtractTo = sinon.stub(utils, 'downloadAndExtractTo').resolves();
   const stubRemove = sinon.stub(fs, 'remove').resolves();
+  const stubMove = sinon.stub(fs, 'move').resolves();
   const stubPathExists = sinon.stub(fs, 'pathExists').resolves(true);
   const stubSymlink = sinon.stub(fs, 'symlink').resolves();
 
   await fetchWithCache(cacheDir, url, target, false);
 
-  t.true(stubDownloadAndExtractTo.calledOnce);
-  t.true(stubRemove.calledTwice);
-  t.false(stubPathExists.called);
-  t.true(stubSymlink.calledOnce);
+  t.true(stubDownloadAndExtractTo.calledOnce, 'downloadAndExtractTo function should called once.');
+  t.true(stubRemove.calledThrice, 'fs.remove function should three times.');
+  t.true(stubMove.calledOnce, 'fs.move function should called once.');
+  t.false(stubPathExists.called, 'fs.pathExists function should not called once.');
+  t.true(stubSymlink.calledOnce, 'fs.symlink function should called once.');
 });


### PR DESCRIPTION
The next time you run pipline, an error will be thrown when you exit the program while downloading