### PR TITLE
cli: import script without copy if the script protocol is `file:`

### DIFF
--- a/packages/cli/src/utils/script.test.ts
+++ b/packages/cli/src/utils/script.test.ts
@@ -41,13 +41,14 @@ test.serial('download script with file protocol', async (t) => {
   const url = 'file:///data/a.js';
   const enableCache = true;
   const stubCopy = sinon.stub(fs, 'copy').resolves();
-  await script.downloadScript(localPath, 1, url, ScriptType.Model, enableCache);
-  t.true(stubCopy.calledOnce, 'fs.copy should be called once');
-  t.deepEqual(
-    stubCopy.args[0],
-    [ '/data/a.js', `${localPath}/1-a.js` ] as any,
-    'fs.copy should called with currect args'
-  );
+  const scriptDesc = await script.downloadScript(localPath, 1, url, ScriptType.Model, enableCache);
+  t.deepEqual(scriptDesc, {
+    name: 'a.js',
+    path: '/data/a.js',
+    type: ScriptType.Model,
+    query: {}
+  }, 'should return correct script');
+  t.false(stubCopy.called, 'fs.copy should not be called');
 });
 
 test.serial('download script with file protocol and query', async (t) => {
@@ -55,13 +56,17 @@ test.serial('download script with file protocol and query', async (t) => {
   const url = 'file:///data/a.js?a=1&b=http://a.b.c';
   const enableCache = true;
   const stubCopy = sinon.stub(fs, 'copy').resolves();
-  await script.downloadScript(localPath, 1, url, ScriptType.Model, enableCache);
-  t.true(stubCopy.calledOnce, 'fs.copy should be called once');
-  t.deepEqual(
-    stubCopy.args[0],
-    [ '/data/a.js', `${localPath}/1-a.js` ] as any,
-    'fs.copy should called with currect args'
-  );
+  const scriptDesc = await script.downloadScript(localPath, 1, url, ScriptType.Model, enableCache);
+  t.deepEqual(scriptDesc, {
+    name: 'a.js',
+    path: '/data/a.js',
+    type: ScriptType.Model,
+    query: {
+      a: '1',
+      b: 'http://a.b.c'
+    }
+  }, 'should return correct script');
+  t.false(stubCopy.called, 'fs.copy should not be called');
 });
 
 async function runPrepare(t: any, enableCache: boolean, withDataflow: boolean) {

--- a/packages/cli/src/utils/script.ts
+++ b/packages/cli/src/utils/script.ts
@@ -7,7 +7,6 @@ import {
 import * as constants from '../constants';
 import * as path from 'path';
 import { parse } from 'url';
-import * as fs from 'fs-extra';
 import { fetchWithCache } from './cache';
 import * as queryString from 'query-string';
 import { DownloadProtocol } from './';

--- a/packages/cli/src/utils/script.ts
+++ b/packages/cli/src/utils/script.ts
@@ -15,11 +15,11 @@ import { DownloadProtocol } from './';
 export const downloadScript = async (scriptDir: string, scriptOrder: number, url: string, type: ScriptType, enableCache: boolean): Promise<PipcookScript> => {
   const urlObj = parse(url);
   const baseName = path.parse(urlObj.pathname).base;
-  const localPath = path.join(scriptDir, `${scriptOrder}-${baseName}`);
+  let localPath = path.join(scriptDir, `${scriptOrder}-${baseName}`);
   const query = queryString.parse(urlObj.query);
-  // if the url is is file protocol, copy without cache
+  // if the url is is file protocol, import it directly.
   if (urlObj.protocol === DownloadProtocol.FILE) {
-    await fs.copy(urlObj.pathname, localPath);
+    localPath = urlObj.pathname;
   } else {
     if (urlObj.protocol === DownloadProtocol.HTTP || urlObj.protocol === DownloadProtocol.HTTPS) {
       // maybe should copy the script with COW

--- a/packages/costa/src/index.ts
+++ b/packages/costa/src/index.ts
@@ -112,13 +112,22 @@ export class Costa {
     const scriptMoudle = await importFrom(script.path);
     let fn: T = scriptMoudle;
     if (typeof fn !== 'function' && type === ScriptType.DataSource) {
-      fn = (fn as any).datasoure;
+      const { datasource } = fn as any;
+      if (typeof datasource === 'function') {
+        fn = datasource;
+      }
     }
     if (typeof fn !== 'function' && type === ScriptType.Dataflow) {
-      fn = (fn as any).dataflow;
+      const { dataflow } = fn as any;
+      if (typeof dataflow === 'function') {
+        fn = dataflow;
+      }
     }
     if (typeof fn !== 'function' && type === ScriptType.Model) {
-      fn = (fn as any).model;
+      const { model } = fn as any;
+      if (typeof model === 'function') {
+        fn = model;
+      }
     }
     fn = typeof fn === 'function' ? fn : scriptMoudle.default;
     if (typeof fn !== 'function') {


### PR DESCRIPTION
We could debug the scripts if the script files are not copied.