### PR TITLE
cli: support relative path for script uri

### DIFF
--- a/packages/cli/src/utils/script.test.ts
+++ b/packages/cli/src/utils/script.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import * as sinon from 'sinon';
 import * as fs from 'fs-extra';
+import * as path from 'path';
 import { ScriptType, PipelineMeta } from '@pipcook/costa';
 import * as constants from '../constants';
 import * as script from './script';
@@ -45,6 +46,21 @@ test.serial('download script with file protocol', async (t) => {
   t.deepEqual(scriptDesc, {
     name: 'a.js',
     path: '/data/a.js',
+    type: ScriptType.Model,
+    query: {}
+  }, 'should return correct script');
+  t.false(stubCopy.called, 'fs.copy should not be called');
+});
+
+test.serial('download script with relative path file protocol', async (t) => {
+  const localPath = process.cwd();
+  const url = 'file:data/a.js';
+  const enableCache = true;
+  const stubCopy = sinon.stub(fs, 'copy').resolves();
+  const scriptDesc = await script.downloadScript(localPath, 1, url, ScriptType.Model, enableCache);
+  t.deepEqual(scriptDesc, {
+    name: 'a.js',
+    path: path.join(process.cwd(), 'data/a.js'),
     type: ScriptType.Model,
     query: {}
   }, 'should return correct script');

--- a/packages/cli/src/utils/script.ts
+++ b/packages/cli/src/utils/script.ts
@@ -18,7 +18,11 @@ export const downloadScript = async (scriptDir: string, scriptOrder: number, url
   const query = queryString.parse(urlObj.query);
   // if the url is is file protocol, import it directly.
   if (urlObj.protocol === DownloadProtocol.FILE) {
-    localPath = urlObj.pathname;
+    if (path.isAbsolute(urlObj.pathname)) {
+      localPath = urlObj.pathname;
+    } else {
+      localPath = path.join(process.cwd(), urlObj.pathname);
+    }
   } else {
     if (urlObj.protocol === DownloadProtocol.HTTP || urlObj.protocol === DownloadProtocol.HTTPS) {
       // maybe should copy the script with COW


### PR DESCRIPTION
As the [RFC-1808](https://tools.ietf.org/html/rfc1808#section-2.2), we could support the relative path for script uri like:
```json
{
    "datasource": "file:relative/path/to/script.js"
}
```
The real path is resolved as `${process.cwd()}/relative/path/to/script.js`.