### PR TITLE
meta: use bent instead of request

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,13 +21,13 @@
     "@pipcook/boa": "^2.1.0",
     "@pipcook/core": "^2.0.0-beta.1",
     "@pipcook/costa": "^2.0.0-beta.1",
+    "bent": "^7.3.12",
     "chalk": "^3.0.0",
     "cli-progress": "^3.9.0",
     "commander": "^4.0.1",
     "debug": "^4.3.1",
     "extract-zip": "^2.0.1",
     "fs-extra": "^8.1.0",
-    "import-fresh": "^3.3.0",
     "nanoid": "^3.1.22",
     "ora": "^3.4.0",
     "pretty-bytes": "^5.6.0",
@@ -36,6 +36,7 @@
     "semver": "^6.3.0"
   },
   "devDependencies": {
+    "@types/bent": "^7.3.2",
     "@types/cli-progress": "^3.9.1",
     "@types/extract-zip": "^1.6.2",
     "@types/fs-extra": "^9.0.9",

--- a/packages/costa/package.json
+++ b/packages/costa/package.json
@@ -20,14 +20,14 @@
     "@pipcook/boa": "^2.1.0",
     "@pipcook/core": "^2.0.0-beta.1",
     "@pipcook/datacook": "^0.0.7",
-    "@types/sinon": "^9.0.11",
-    "debug": "^4.1.1",
-    "sinon": "^10.0.0"
+    "debug": "^4.1.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
+    "@types/sinon": "^9.0.11",
     "ava": "^3.13.0",
     "nyc": "^15.1.0",
+    "sinon": "^10.0.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.2"
   },


### PR DESCRIPTION
The module `request` has been deprecated, see https://github.com/request/request/issues/3142, use `bent` instead of it.